### PR TITLE
PoC: Running postgres with credentials

### DIFF
--- a/postgresql/Makefile
+++ b/postgresql/Makefile
@@ -7,4 +7,5 @@ gen-postgresql:
 			--env BITNAMI_POSTGRES_RELEASE=${BITNAMI_POSTGRESQL_RELEASE} \
 			--workdir=/opt/manifests \
 			--entrypoint=/bin/sh \
+			--env NS=dev-enablement \
 			alpine/helm ./gen-yaml/gen.sh

--- a/postgresql/examples/kustomization.yaml
+++ b/postgresql/examples/kustomization.yaml
@@ -10,6 +10,8 @@ secretGenerator:
   - name: postgresql
     envs:
       - secrets/postgres.properties
+    options:
+      disableNameSuffixHash: true
 patches:
 #  - path: backup.yaml
   - path: backup-pvc.yaml

--- a/postgresql/examples/kustomization.yaml
+++ b/postgresql/examples/kustomization.yaml
@@ -1,16 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namePrefix: crm-graphql
-namespace: "energy-platform"
-commonLabels:
-  app: crm-graphql-postgres
+#namePrefix: crm-graphql
+#namespace: "energy-platform"
+#commonLabels:
+#  app: crm-graphql-postgres
 resources:
   - http://github.com/utilitywarehouse/shared-kustomize-bases//postgresql/manifests?ref=SFE-356/shared-postgres
 secretGenerator:
-  - name: postgres-secrets
+  - name: postgresql
     envs:
       - secrets/postgres.properties
 patches:
-  - path: backup.yaml
+#  - path: backup.yaml
   - path: backup-pvc.yaml
   - path: postgres.yaml

--- a/postgresql/examples/kustomization.yaml
+++ b/postgresql/examples/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 #commonLabels:
 #  app: crm-graphql-postgres
 resources:
-  - http://github.com/utilitywarehouse/shared-kustomize-bases//postgresql/manifests?ref=SFE-356/shared-postgres
+  - http://github.com/utilitywarehouse/shared-kustomize-bases//postgresql/manifests?ref=marcin-postgres-test
 secretGenerator:
   - name: postgresql
     envs:
@@ -13,4 +13,4 @@ secretGenerator:
 patches:
 #  - path: backup.yaml
   - path: backup-pvc.yaml
-  - path: postgres.yaml
+#  - path: postgres.yaml

--- a/postgresql/examples/postgres.yaml
+++ b/postgresql/examples/postgres.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: postgresql
+  namespace: dev-enablement
 spec:
   volumeClaimTemplates:
     - spec:

--- a/postgresql/examples/secrets/postgres.properties
+++ b/postgresql/examples/secrets/postgres.properties
@@ -1,1 +1,2 @@
-password=some_password
+user-password=some_password
+password=some_admin_password

--- a/postgresql/examples/secrets/postgres.properties
+++ b/postgresql/examples/secrets/postgres.properties
@@ -1,4 +1,4 @@
-user: <your-user-here>
-password: <your-password-here>
-database: <your-database-here>
-url: postgresql://<your-user-here>:<your-password-here>@<your-postgres-host-here>/<your-database-here>?sslmode=disable
+user=some_user
+password=some_password
+database=some_database
+url=postgresql://some_user:some_password@localhost/some_database?sslmode=disable

--- a/postgresql/examples/secrets/postgres.properties
+++ b/postgresql/examples/secrets/postgres.properties
@@ -1,4 +1,1 @@
-user=some_user
 password=some_password
-database=some_database
-url=postgresql://some_user:some_password@localhost/some_database?sslmode=disable

--- a/postgresql/gen-yaml/gen.sh
+++ b/postgresql/gen-yaml/gen.sh
@@ -8,6 +8,7 @@ rm -f manifests/upstream/*
 # Fetch from helm repo: https://github.com/bitnami/charts/tree/main/bitnami/postgresql
 helm repo add bitnami https://charts.bitnami.com/bitnami
 
+# PGPASSWORD=some_password psql -U some_user -h localhost -p 5432 -d postgres
 helm template "postgresql" bitnami/postgresql --version "${BITNAMI_POSTGRES_RELEASE}" \
   --set fullnameOverride="postgresql" \
   --set nameOverride="postgresql" \
@@ -17,8 +18,8 @@ helm template "postgresql" bitnami/postgresql --version "${BITNAMI_POSTGRES_RELE
   --set auth.existingSecret="postgresql" \
   --set auth.secretKeys.adminPasswordKey="password" \
   --set auth.secretKeys.userPasswordKey="user-password" \
-  --set auth.database="database" \
-  --set global.postgresql.auth.username="some_user" \
+  --set global.postgresql.auth.database="database" \
+  --set global.postgresql.auth.username="testuser" \
   --set primary.resources.requests.cpu="0" \
   --set primary.resources.limits.cpu="1000m" \
   --set primary.resources.requests.memory="0" \

--- a/postgresql/gen-yaml/gen.sh
+++ b/postgresql/gen-yaml/gen.sh
@@ -18,14 +18,13 @@ helm template "postgresql" bitnami/postgresql --version "${BITNAMI_POSTGRES_RELE
   --set auth.secretKeys.adminPasswordKey="password" \
   --set auth.secretKeys.userPasswordKey="user-password" \
   --set auth.database="database" \
+  --set global.postgresql.auth.username="some_user" \
   --set primary.resources.requests.cpu="0" \
   --set primary.resources.limits.cpu="1000m" \
   --set primary.resources.requests.memory="0" \
   --set primary.resources.limits.memory="1Gi" \
   --set metrics.enabled="true" \
   --set backup.enabled="false" \
-  --set global.postgresql.auth.username="some_user" \
-  --set global.postgresql.auth.database="some_db" \
   --namespace "${NS}" > manifests/upstream/postgres.yaml
 
 cp gen-yaml/kustomization.yaml manifests/upstream/kustomization.yaml

--- a/postgresql/gen-yaml/gen.sh
+++ b/postgresql/gen-yaml/gen.sh
@@ -24,6 +24,8 @@ helm template "postgresql" bitnami/postgresql --version "${BITNAMI_POSTGRES_RELE
   --set primary.resources.limits.memory="1Gi" \
   --set metrics.enabled="true" \
   --set backup.enabled="false" \
+  --set global.postgresql.auth.username="some_user" \
+  --set global.postgresql.auth.database="some_db" \
   --namespace "${NS}" > manifests/upstream/postgres.yaml
 
 cp gen-yaml/kustomization.yaml manifests/upstream/kustomization.yaml

--- a/postgresql/gen-yaml/gen.sh
+++ b/postgresql/gen-yaml/gen.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 set -o errexit -o pipefail -o nounset
@@ -19,11 +18,12 @@ helm template "postgresql" bitnami/postgresql --version "${BITNAMI_POSTGRES_RELE
   --set auth.secretKeys.adminPasswordKey="password" \
   --set auth.secretKeys.userPasswordKey="user-password" \
   --set auth.database="database" \
-  --set master.resources.requests.cpu="0" \
-  --set master.resources.limits.cpu="1000m" \
-  --set master.resources.requests.memory="0" \
-  --set master.resources.limits.memory="1Gi" \
+  --set primary.resources.requests.cpu="0" \
+  --set primary.resources.limits.cpu="1000m" \
+  --set primary.resources.requests.memory="0" \
+  --set primary.resources.limits.memory="1Gi" \
   --set metrics.enabled="true" \
-  --set backup.enabled="false" > manifests/upstream/postgres.yaml
+  --set backup.enabled="false" \
+  --namespace "${NS}" > manifests/upstream/postgres.yaml
 
 cp gen-yaml/kustomization.yaml manifests/upstream/kustomization.yaml

--- a/postgresql/manifests/upstream/postgres.yaml
+++ b/postgresql/manifests/upstream/postgres.yaml
@@ -183,13 +183,20 @@ spec:
             - name: PGDATA
               value: "/bitnami/postgresql/data"
             # Authentication
+            - name: POSTGRES_USER
+              value: "some_user"
             - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: user-password
+            - name: POSTGRES_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: postgresql
                   key: password
             - name: POSTGRES_DATABASE
-              value: "database"
+              value: "some_db"
             # Replication
             # Initdb
             # Standby
@@ -226,7 +233,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - exec pg_isready -U "postgres" -d "dbname=database" -h 127.0.0.1 -p 5432
+                - exec pg_isready -U "some_user" -d "dbname=some_db" -h 127.0.0.1 -p 5432
           readinessProbe:
             failureThreshold: 6
             initialDelaySeconds: 5
@@ -239,7 +246,7 @@ spec:
                 - -c
                 - -e
                 - |
-                  exec pg_isready -U "postgres" -d "dbname=database" -h 127.0.0.1 -p 5432
+                  exec pg_isready -U "some_user" -d "dbname=some_db" -h 127.0.0.1 -p 5432
                   [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
           resources:
             limits:
@@ -269,14 +276,14 @@ spec:
               type: RuntimeDefault
           env:
             - name: DATA_SOURCE_URI
-              value: 127.0.0.1:5432/database?sslmode=disable
+              value: 127.0.0.1:5432/some_db?sslmode=disable
             - name: DATA_SOURCE_PASS
               valueFrom:
                 secretKeyRef:
                   name: postgresql
-                  key: password
+                  key: user-password
             - name: DATA_SOURCE_USER
-              value: "postgres"
+              value: "some_user"
           ports:
             - name: http-metrics
               containerPort: 9187

--- a/postgresql/manifests/upstream/postgres.yaml
+++ b/postgresql/manifests/upstream/postgres.yaml
@@ -242,10 +242,12 @@ spec:
                   exec pg_isready -U "postgres" -d "dbname=database" -h 127.0.0.1 -p 5432
                   [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
           resources:
-            limits: {}
+            limits:
+              cpu: 1000m
+              memory: 1Gi
             requests:
-              cpu: 250m
-              memory: 256Mi
+              cpu: 0
+              memory: 0
           volumeMounts:
             - name: dshm
               mountPath: /dev/shm

--- a/postgresql/manifests/upstream/postgres.yaml
+++ b/postgresql/manifests/upstream/postgres.yaml
@@ -196,7 +196,7 @@ spec:
                   name: postgresql
                   key: password
             - name: POSTGRES_DATABASE
-              value: "some_db"
+              value: "database"
             # Replication
             # Initdb
             # Standby
@@ -233,7 +233,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - exec pg_isready -U "some_user" -d "dbname=some_db" -h 127.0.0.1 -p 5432
+                - exec pg_isready -U "some_user" -d "dbname=database" -h 127.0.0.1 -p 5432
           readinessProbe:
             failureThreshold: 6
             initialDelaySeconds: 5
@@ -246,7 +246,7 @@ spec:
                 - -c
                 - -e
                 - |
-                  exec pg_isready -U "some_user" -d "dbname=some_db" -h 127.0.0.1 -p 5432
+                  exec pg_isready -U "some_user" -d "dbname=database" -h 127.0.0.1 -p 5432
                   [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
           resources:
             limits:
@@ -276,7 +276,7 @@ spec:
               type: RuntimeDefault
           env:
             - name: DATA_SOURCE_URI
-              value: 127.0.0.1:5432/some_db?sslmode=disable
+              value: 127.0.0.1:5432/database?sslmode=disable
             - name: DATA_SOURCE_PASS
               valueFrom:
                 secretKeyRef:

--- a/postgresql/manifests/upstream/postgres.yaml
+++ b/postgresql/manifests/upstream/postgres.yaml
@@ -184,7 +184,7 @@ spec:
               value: "/bitnami/postgresql/data"
             # Authentication
             - name: POSTGRES_USER
-              value: "some_user"
+              value: "testuser"
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -233,7 +233,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - exec pg_isready -U "some_user" -d "dbname=database" -h 127.0.0.1 -p 5432
+                - exec pg_isready -U "testuser" -d "dbname=database" -h 127.0.0.1 -p 5432
           readinessProbe:
             failureThreshold: 6
             initialDelaySeconds: 5
@@ -246,7 +246,7 @@ spec:
                 - -c
                 - -e
                 - |
-                  exec pg_isready -U "some_user" -d "dbname=database" -h 127.0.0.1 -p 5432
+                  exec pg_isready -U "testuser" -d "dbname=database" -h 127.0.0.1 -p 5432
                   [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
           resources:
             limits:
@@ -283,7 +283,7 @@ spec:
                   name: postgresql
                   key: user-password
             - name: DATA_SOURCE_USER
-              value: "some_user"
+              value: "testuser"
           ports:
             - name: http-metrics
               containerPort: 9187

--- a/postgresql/manifests/upstream/postgres.yaml
+++ b/postgresql/manifests/upstream/postgres.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgresql-metrics
-  namespace: "default"
+  namespace: "dev-enablement"
   labels:
     app.kubernetes.io/instance: postgresql
     app.kubernetes.io/managed-by: Helm
@@ -35,7 +35,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgresql-hl
-  namespace: "default"
+  namespace: "dev-enablement"
   labels:
     app.kubernetes.io/instance: postgresql
     app.kubernetes.io/managed-by: Helm
@@ -73,7 +73,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgresql
-  namespace: "default"
+  namespace: "dev-enablement"
   labels:
     app.kubernetes.io/instance: postgresql
     app.kubernetes.io/managed-by: Helm
@@ -103,7 +103,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: postgresql
-  namespace: "default"
+  namespace: "dev-enablement"
   labels:
     app.kubernetes.io/instance: postgresql
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
I made a few changes, which are allowing the example to run.
To test it change the namespace, regenerate manifests and run:
bash```
kubectl --context dev-merit -n <NAMESPACE> apply -k examples
kubectl --context dev-merit -n <NAMESPACE> port-forward svc/postgresql 5432
PGPASSWORD=some_password psql -U testuser -h localhost -p 5432 -d postgres
```

Before creating the postgres, make sure that there is no PVC remaining from previous postgres- otherwise, user specified in chart won't be created.

I also:
-added the username to chart, not secret (it is not created from secret)
-removed patches breaking the example
-removed unnecessary variables from secret
-used correct parameter to set the resources
-adjusted the charts to dev-enablement ns (sorry about that :slightly_smiling_face: )


