### PR TITLE
directory with common components

### DIFF
--- a/common-overlays/kustomization.yaml
+++ b/common-overlays/kustomization.yaml
@@ -1,0 +1,30 @@
+patches:
+  # remove namespace
+  - patch: |-
+      - op: remove
+        path: /metadata/namespace
+    target:
+      namespace: default
+  # Remove unnecessary `app.kubernetes.io/managed-by: Helm` annotation
+  - patch: |-
+      - op: remove
+        path: /metadata/labels/app.kubernetes.io~1managed-by
+    target: { } # All resources
+  - patch: |-
+      - op: remove
+        path: /spec/template/metadata/labels/app.kubernetes.io~1managed-by
+    target:
+      group: apps
+      version: v1
+      kind: StatefulSet
+  # remove these empty affinity nodes, as in Kustomize 5.0.x kustomize generates them as strings with value "null" instead of just null, and they can not be applied.
+  # added this issue in kustomize: https://github.com/kubernetes-sigs/kustomize/issues/5171
+  - patch: |-
+      - op: remove
+        path: /spec/template/spec/affinity/podAffinity
+      - op: remove
+        path: /spec/template/spec/affinity/nodeAffinity
+    target:
+      group: apps
+      version: v1
+      kind: StatefulSet

--- a/components/bitnami-common/kustomization.yaml
+++ b/components/bitnami-common/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
 patches:
   # remove namespace
   - patch: |-

--- a/redis/gen-yaml/gen.sh
+++ b/redis/gen-yaml/gen.sh
@@ -17,8 +17,4 @@ helm template "redis" bitnami/redis --version "${BITNAMI_REDIS_RELEASE}" \
   --set master.resources.limits.cpu="1000m" \
   --set master.resources.requests.memory="1Gi" \
   --set master.resources.limits.memory="2Gi" \
-  --set replica.resources.requests.cpu="500m" \
-  --set replica.resources.limits.cpu="1000m" \
-  --set replica.resources.requests.memory="1Gi" \
-  --set replica.resources.limits.memory="2Gi" \
   > "manifests/redis.yaml"

--- a/redis/manifests/kustomization.yaml
+++ b/redis/manifests/kustomization.yaml
@@ -3,34 +3,4 @@ kind: Kustomization
 
 resources:
   - redis.yaml
-
-patches:
-  # remove namespace
-  - patch: |-
-      - op: remove
-        path: /metadata/namespace
-    target:
-      namespace: default
-  # Remove unnecessary `app.kubernetes.io/managed-by: Helm` annotation
-  - patch: |-
-      - op: remove
-        path: /metadata/labels/app.kubernetes.io~1managed-by
-    target: { } # All resources
-  - patch: |-
-      - op: remove
-        path: /spec/template/metadata/labels/app.kubernetes.io~1managed-by
-    target:
-      group: apps
-      version: v1
-      kind: StatefulSet
-  # remove these empty affinity nodes, as in Kustomize 5.0.x kustomize generates them as strings with value "null" instead of just null, and they can not be applied.
-  # added this issue in kustomize: https://github.com/kubernetes-sigs/kustomize/issues/5171
-  - patch: |-
-      - op: remove
-        path: /spec/template/spec/affinity/podAffinity
-      - op: remove
-        path: /spec/template/spec/affinity/nodeAffinity
-    target:
-      group: apps
-      version: v1
-      kind: StatefulSet
+  - ../../common-overlays

--- a/redis/manifests/kustomization.yaml
+++ b/redis/manifests/kustomization.yaml
@@ -3,4 +3,6 @@ kind: Kustomization
 
 resources:
   - redis.yaml
-  - ../../common-overlays
+
+components:
+  - ../../components/bitnami-common


### PR DESCRIPTION
This PR creates the directory with components reusable between charts. It also adds the first commonly used component- set of patches that will have to be applied for all the Bitnami charts.
It also removes the redis replica resources settings, since they are not used- we are not deploying redis replica anyway.