### PR TITLE
[DENA-427] use helm values file instead of passing them via bash script

### DIFF
--- a/elasticsearch/gen-yaml/gen.sh
+++ b/elasticsearch/gen-yaml/gen.sh
@@ -5,25 +5,7 @@ set -o errexit -o pipefail -o nounset
 # Fetch from helm repo: https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
 helm repo add bitnami https://charts.bitnami.com/bitnami
 
-helm template "elasticsearch" bitnami/elasticsearch --version "${BITNAMI_ES_RELEASE}" \
-  --set commonAnnotations."app\.uw\.systems\/repos"="https://github.com/utilitywarehouse/shared-kustomize-bases/tree/main/elasticsearch" \
-  --set global.kibanaEnabled="true" \
-  --set metrics.enabled="true" \
-  --set master.replicaCount="3" \
-  --set master.masterOnly="false" \
-  --set data.replicaCount="0" \
-  --set coordinating.replicaCount="0" \
-  --set ingest.replicaCount="0" \
-  --set master.resources.requests.cpu="250m" \
-  --set master.resources.limits.cpu="2000m" \
-  --set master.resources.requests.memory="4Gi" \
-  --set master.resources.limits.memory="8Gi" \
-  --set master.persistence.size="100Gi" \
-  --set sysctlImage.enabled="false" \
-  --set kibana.resources.requests.cpu="250m" \
-  --set kibana.resources.limits.cpu="1000m" \
-  --set kibana.resources.requests.memory="200Mi" \
-  --set kibana.resources.limits.memory="1Gi" \
-  --set kibana.commonAnnotations."app\.uw\.systems\/repos"="https://github.com/utilitywarehouse/shared-kustomize-bases/tree/main/elasticsearch" \
-  --set kibana.metrics.enabled="true" \
+curDir="$(dirname "$0")"
+
+helm template "elasticsearch" bitnami/elasticsearch --version "${BITNAMI_ES_RELEASE}"  --values "$curDir"/values.yaml \
   >"manifests/elasticsearch.yaml"

--- a/elasticsearch/gen-yaml/values.yaml
+++ b/elasticsearch/gen-yaml/values.yaml
@@ -1,0 +1,48 @@
+commonAnnotations:
+  "app.uw.systems/repos": "https://github.com/utilitywarehouse/shared-kustomize-bases/tree/main/elasticsearch"
+
+global:
+  kibanaEnabled: true
+
+metrics:
+  enabled: true
+
+master:
+  replicaCount: "3"
+  # master node are multipurpose
+  masterOnly: false
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "4Gi"
+    limits:
+      cpu: "2000m"
+      memory: "8Gi"
+  persistence:
+    size: "100Gi"
+
+# Disable nodes other than multipurpose master
+data:
+  replicaCount: "0"
+coordinating:
+  replicaCount: "0"
+ingest:
+  replicaCount: "0"
+
+# disable privileged init image setting the kernel values for max amount of file descriptors and memory map areas.
+# those settings are necessary for ES to work, but they are already set to sufficient values on the cluster.
+sysctlImage:
+  enabled: false
+
+kibana:
+  commonAnnotations:
+    "app.uw.systems/repos": "https://github.com/utilitywarehouse/shared-kustomize-bases/tree/main/elasticsearch"
+  metrics:
+    enabled: true
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "200Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"

--- a/redis/gen-yaml/gen.sh
+++ b/redis/gen-yaml/gen.sh
@@ -5,16 +5,7 @@ set -o errexit -o pipefail -o nounset
 # Fetch from helm repo: https://github.com/bitnami/charts/tree/main/bitnami/redis
 helm repo add bitnami https://charts.bitnami.com/bitnami
 
-helm template "redis" bitnami/redis --version "${BITNAMI_REDIS_RELEASE}" \
-  --set fullnameOverride="redis" \
-  --set nameOverride="redis" \
-  --set commonAnnotations."app\.uw\.systems\/repos"="https://github.com/utilitywarehouse/shared-kustomize-bases/tree/main/redis" \
-  --set auth.existingSecret="redis" \
-  --set architecture=standalone \
-  --set metrics.enabled="true" \
-  --set master.disableCommands="" \
-  --set master.resources.requests.cpu="500m" \
-  --set master.resources.limits.cpu="1000m" \
-  --set master.resources.requests.memory="1Gi" \
-  --set master.resources.limits.memory="2Gi" \
+curDir="$(dirname "$0")"
+
+helm template "redis" bitnami/redis --version "${BITNAMI_REDIS_RELEASE}" --values "$curDir"/values.yaml \
   > "manifests/redis.yaml"

--- a/redis/gen-yaml/values.yaml
+++ b/redis/gen-yaml/values.yaml
@@ -1,0 +1,24 @@
+commonAnnotations:
+  "app.uw.systems/repos": "https://github.com/utilitywarehouse/shared-kustomize-bases/tree/main/redis"
+
+auth:
+  existingSecret: "redis"
+
+# redis instance without replication
+architecture: "standalone"
+
+metrics:
+  enabled: true
+
+master:
+  # orignial chart disables commands flushdb and flushall.
+  # we don't want to do that
+  disableCommands: ""
+
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "1000m"
+      memory: "2Gi"


### PR DESCRIPTION
Manifests are regenerated, but there is no changes. 
I am aware both of the gen.sh scipts are almost the same. I restrained the urge to have one, generic script generating the manifests- the future might bring the need to differentiation of script. 