### PR TITLE
Increase es heap size

### DIFF
--- a/elasticsearch/gen-yaml/values.yaml
+++ b/elasticsearch/gen-yaml/values.yaml
@@ -11,6 +11,7 @@ master:
   replicaCount: "3"
   # master node are multipurpose
   masterOnly: false
+  heapSize: "4g"
   resources:
     requests:
       cpu: "250m"

--- a/elasticsearch/gen-yaml/values.yaml
+++ b/elasticsearch/gen-yaml/values.yaml
@@ -11,7 +11,7 @@ master:
   replicaCount: "3"
   # master node are multipurpose
   masterOnly: false
-  heapSize: "4g"
+  heapSize: "1g"
   resources:
     requests:
       cpu: "250m"

--- a/elasticsearch/gen-yaml/values.yaml
+++ b/elasticsearch/gen-yaml/values.yaml
@@ -11,7 +11,7 @@ master:
   replicaCount: "3"
   # master node are multipurpose
   masterOnly: false
-  heapSize: "1g"
+  heapSize: "4g"
   resources:
     requests:
       cpu: "250m"

--- a/elasticsearch/manifests/elasticsearch.yaml
+++ b/elasticsearch/manifests/elasticsearch.yaml
@@ -439,7 +439,7 @@ spec:
             - name: ELASTICSEARCH_ADVERTISED_HOSTNAME
               value: "$(MY_POD_NAME).elasticsearch-master-hl.default.svc.cluster.local"
             - name: ELASTICSEARCH_HEAP_SIZE
-              value: "4g"
+              value: "1g"
           ports:
             - name: rest-api
               containerPort: 9200

--- a/elasticsearch/manifests/elasticsearch.yaml
+++ b/elasticsearch/manifests/elasticsearch.yaml
@@ -439,7 +439,7 @@ spec:
             - name: ELASTICSEARCH_ADVERTISED_HOSTNAME
               value: "$(MY_POD_NAME).elasticsearch-master-hl.default.svc.cluster.local"
             - name: ELASTICSEARCH_HEAP_SIZE
-              value: "128m"
+              value: "4g"
           ports:
             - name: rest-api
               containerPort: 9200

--- a/elasticsearch/manifests/elasticsearch.yaml
+++ b/elasticsearch/manifests/elasticsearch.yaml
@@ -439,7 +439,7 @@ spec:
             - name: ELASTICSEARCH_ADVERTISED_HOSTNAME
               value: "$(MY_POD_NAME).elasticsearch-master-hl.default.svc.cluster.local"
             - name: ELASTICSEARCH_HEAP_SIZE
-              value: "1g"
+              value: "4g"
           ports:
             - name: rest-api
               containerPort: 9200


### PR DESCRIPTION
```
The general recommendation is to allocate 50% of the available system memory to Elasticsearch, with a maximum of 32GB.
```
Source: https://opster.com/guides/elasticsearch/capacity-planning/elasticsarch-java-heap-size/