### PR TITLE
scale up es-topic-indexer

### DIFF
--- a/elasticsearch/example/env-patch.yaml
+++ b/elasticsearch/example/env-patch.yaml
@@ -3,16 +3,11 @@ kind: StatefulSet
 metadata:
   name: elasticsearch-master
 spec:
-  replicas: 1
   template:
     spec:
       containers:
         - name: elasticsearch
           env:
-            # This patch changes the master hosts- to use just one. It allows scaling the
-            # ES down to one node.
-            - name: ELASTICSEARCH_CLUSTER_MASTER_HOSTS
-              value: "elasticsearch-master-0"
             # This patch adjusts the java heap size for the elasticsearch container
             # recommended value is half of available memory
             - name: ELASTICSEARCH_HEAP_SIZE

--- a/elasticsearch/example/kustomization.yaml
+++ b/elasticsearch/example/kustomization.yaml
@@ -11,7 +11,6 @@ commonAnnotations:
   "app.uw.systems/tier": "tier_4"
 
 patches:
-  # Scaling the nodes down to 1- change amount of replicas and hostnames of the nodes
   # changing the heap size
   - path: env-patch.yaml
   # PVC size


### PR DESCRIPTION


Because cluster with one node is not a representative example for elasticsearch- it demands special setup (no node discovery)
