### PR TITLE
[DENA-451] Shared manifest for es-topic-indexer

### DIFF
--- a/es-topic-indexer/README.md
+++ b/es-topic-indexer/README.md
@@ -1,0 +1,1 @@
+# es-topic-indexer

--- a/es-topic-indexer/README.md
+++ b/es-topic-indexer/README.md
@@ -6,4 +6,5 @@ This manifest is used to deploy [es-topic-indexer](https://github.com/utilitywar
 
 ## Usage
 
-See [service repository](https://github.com/utilitywarehouse/es-topic-indexer) for usage details
+See [service repository](https://github.com/utilitywarehouse/es-topic-indexer) for usage details. See directory [example](example)
+for example kustomization file deploying es-topic-indexer.

--- a/es-topic-indexer/README.md
+++ b/es-topic-indexer/README.md
@@ -1,1 +1,9 @@
 # es-topic-indexer
+
+## Source
+
+This manifest is used to deploy [es-topic-indexer](https://github.com/utilitywarehouse/es-topic-indexer).
+
+## Usage
+
+See [service repository](https://github.com/utilitywarehouse/es-topic-indexer) for usage details

--- a/es-topic-indexer/example/indexer-params.yaml
+++ b/es-topic-indexer/example/indexer-params.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: &app es-topic-indexer
+spec:
+  template:
+    spec:
+      containers:
+        - name: *app
+          env:
+            - name: ES_HOSTS
+              value: "http://elasticsearch:9200"
+            - name: ES_INDEX_NAME
+              value: "example-index-name"
+            - name: KAFKA_BROKERS
+              value: "kafka:9092,kafka2:9092"
+            - name: KAFKA_TOPIC
+              value: "example-topic-1,example-topic-2"
+            - name: KAFKA_CONSUMER_GROUP
+              value: "dev-enablement.example-consumer-group"
+            - name: KAFKA_CONSUME_OLDEST
+              value: "false"
+            - name: UW_KAFKA_TLS_AUTH
+              value: "true"
+      volumes:
+        - name: kafka-client-cert
+          secret:
+            # as specified in certificate. This secret is necessary for TLS
+            secretName: es-topic-indexer-kafka-client-cert

--- a/es-topic-indexer/example/indexer-params.yaml
+++ b/es-topic-indexer/example/indexer-params.yaml
@@ -22,6 +22,7 @@ spec:
               value: "false"
             - name: UW_KAFKA_TLS_AUTH
               value: "true"
+          image: registry.uw.systems/dev-enablement/protobuf-contracts-es-indexer:latest
       volumes:
         - name: kafka-client-cert
           secret:

--- a/es-topic-indexer/example/indexer-params.yaml
+++ b/es-topic-indexer/example/indexer-params.yaml
@@ -14,7 +14,7 @@ spec:
               value: "example-index-name"
             - name: KAFKA_BROKERS
               value: "kafka:9092,kafka2:9092"
-            - name: KAFKA_TOPIC
+            - name: KAFKA_TOPICS
               value: "example-topic-1,example-topic-2"
             - name: KAFKA_CONSUMER_GROUP
               value: "dev-enablement.example-consumer-group"

--- a/es-topic-indexer/example/kafka-certificate.yaml
+++ b/es-topic-indexer/example/kafka-certificate.yaml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: es-topic-indexer-kafka-client
+spec:
+  # specify certificate name, as specified in kafka-cluster-config
+  # https://github.com/utilitywarehouse/kafka-cluster-config/tree/193fea06658d9359f8f86256c87ca717539c3d7b/modules/tls-app
+  commonName: dev-enablement/example-app
+  # es-topic-indexer consumer group
+  dnsNames:
+    - dev-enablement.example-consumer-group
+  duration: 168h0m0s # 7 days, renews 2/3 of the way through
+  issuerRef:
+    kind: ClusterIssuer
+    name: kafka-shared-selfsigned-issuer
+  secretName: es-topic-indexer-kafka-client-cert

--- a/es-topic-indexer/example/kustomization.yaml
+++ b/es-topic-indexer/example/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  #- ssh://github.com/utilitywarehouse/shared-kustomize-bases//es-topic-indexer/manifests?ref=v0.0.0
+  - ../manifests
+
+
+# Add prefix to name
+namePrefix: sample-event-
+
+# OpsLevel annotations
+commonAnnotations:
+  "app.uw.systems/description": "Sample events indexer"
+  "app.uw.systems/tier": "tier_4"
+
+patches:
+  - path: indexer-params.yaml
+  - path: kafka-certificate.yaml

--- a/es-topic-indexer/example/kustomization.yaml
+++ b/es-topic-indexer/example/kustomization.yaml
@@ -9,11 +9,6 @@ resources:
 # Add prefix to name
 namePrefix: sample-event-
 
-# OpsLevel annotations
-commonAnnotations:
-  "app.uw.systems/description": "Sample events indexer"
-  "app.uw.systems/tier": "tier_4"
-
 patches:
   - path: indexer-params.yaml
   - path: kafka-certificate.yaml

--- a/es-topic-indexer/manifests/es-topic-indexer.yaml
+++ b/es-topic-indexer/manifests/es-topic-indexer.yaml
@@ -67,17 +67,3 @@ spec:
               memory: 1Gi
           ports:
             - containerPort: 8081
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: es-topic-indexer-kafka-client
-spec:
-  commonName: dev-enablement/es-topic-indexer
-  dnsNames:
-    - es-topic-indexer.dev-enablement
-  duration: 168h0m0s # 7 days, renews 2/3 of the way through
-  issuerRef:
-    kind: ClusterIssuer
-    name: kafka-shared-selfsigned-issuer
-  secretName: es-topic-indexer-kafka-client-cert

--- a/es-topic-indexer/manifests/es-topic-indexer.yaml
+++ b/es-topic-indexer/manifests/es-topic-indexer.yaml
@@ -34,7 +34,7 @@ spec:
               value: "pubsub-example-sample-message"
             - name: KAFKA_BROKERS
               value: "kafka:9092,kafka2:9092"
-            - name: KAFKA_TOPIC
+            - name: KAFKA_TOPICS
               value: "account.exceptions.v1,account.exceptions.v2"
             - name: KAFKA_CONSUMER_GROUP
               value: "account-exceptions-v1"

--- a/es-topic-indexer/manifests/es-topic-indexer.yaml
+++ b/es-topic-indexer/manifests/es-topic-indexer.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: &app es-topic-indexer
+  annotations:
+    app.uw.systems/tier: "tier_4"
+    app.uw.systems/repos.es-topic-indexer: "https://github.com/utilitywarehouse/es-topic-indexer"
+    app.uw.systems/description: "Saves Kafka messages to Elasticsearch"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: *app
+  template:
+    metadata:
+      labels:
+        app: *app
+        #policy.semaphore.uw.io/name: *app
+      annotations:
+        prometheus.io/path: /__/metrics
+        prometheus.io/port: '8081'
+        prometheus.io/scrape: 'true'
+    spec:
+      imagePullSecrets:
+        - name: dockerhub-key
+      containers:
+        - name: *app
+          env:
+            - name: ES_HOSTS
+              value: "http://elasticsearch:9200"
+            - name: ES_INDEX_NAME
+              value: "pubsub-example-sample-message"
+            - name: KAFKA_BROKERS
+              value: "kafka:9092,kafka2:9092"
+            - name: KAFKA_TOPIC
+              value: "account.exceptions.v1,account.exceptions.v2"
+            - name: KAFKA_CONSUMER_GROUP
+              value: "account-exceptions-v1"
+            - name: KAFKA_CONSUME_OLDEST
+              value: "false"
+            - name: UW_KAFKA_TLS_AUTH
+              value: "true"
+          volumeMounts:
+            - name: kafka-client-cert
+              mountPath: /certs
+              readOnly: true
+          image: registry.uw.systems/dev-enablement/protobuf-contracts-es-indexer:latest
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /__/ready
+              port: 8081
+            initialDelaySeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /__/ready
+              port: 8081
+            initialDelaySeconds: 20
+          resources:
+            requests:
+              cpu: 0
+              memory: 500Mi
+            limits:
+              cpu: 1
+              memory: 1Gi
+          ports:
+            - containerPort: 8081
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: es-topic-indexer-kafka-client
+spec:
+  commonName: dev-enablement/es-topic-indexer
+  dnsNames:
+    - es-topic-indexer.dev-enablement
+  duration: 168h0m0s # 7 days, renews 2/3 of the way through
+  issuerRef:
+    kind: ClusterIssuer
+    name: kafka-shared-selfsigned-issuer
+  secretName: es-topic-indexer-kafka-client-cert

--- a/es-topic-indexer/manifests/kustomization.yaml
+++ b/es-topic-indexer/manifests/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - es-topic-indexer.yaml


### PR DESCRIPTION
Currently, every deployed es-topic-indexer uses copy- pasted manifest code. This should be better approach.

[PR to use shared-kustomize-bases for deployment of our es-topic-indexer](https://github.com/utilitywarehouse/kubernetes-manifests/pull/84968)