### PR TITLE
Fix Redis and Elasticsearch failing OpsLevel checks

### DIFF
--- a/components/opslevel/kustomization.yaml
+++ b/components/opslevel/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  # add oss tag for objects running 3rd party software
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+    patch: &oss-patch |-
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1tags.oss
+        value: "true"
+  - target:
+      version: v1
+      group: apps
+      kind: StatefulSet
+    patch: *oss-patch

--- a/elasticsearch/manifests/kustomization.yaml
+++ b/elasticsearch/manifests/kustomization.yaml
@@ -22,3 +22,4 @@ patches:
 
 components:
   - ../../components/bitnami-common
+  - ../../components/opslevel

--- a/redis/manifests/kustomization.yaml
+++ b/redis/manifests/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 
 components:
   - ../../components/bitnami-common
+  - ../../components/opslevel


### PR DESCRIPTION
Because we default the language of services in OpsLevel to 'Go' these were failing Go checks, though they're clearly not Go services. Mark them as OSS to reduce the number of required checks and make it clear that these are services running 3rd party software.

A component was added to handle this so that it can be easily re-used across future manifests.

Ticket: DENA-480