### PR TITLE
[DENA-489] github workflow

### DIFF
--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -1,8 +1,6 @@
 name: Check manifests
 on:
   pull_request:
-    branches:
-      - '*'
 
 jobs:
   # run `kustomize build` over changed kustomize directories

--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -133,30 +133,3 @@ jobs:
         with:
           name: manifests
           path: built-manifests/
-
-  validate-opslevel-annotations:
-    # run some basic checks against the OpsLevel annotations (or lack thereof) in the manifests
-    # powered by https://github.com/utilitywarehouse/dev-enablement-mono/blob/main/cmd/validate-opslevel-annotations/main.go
-    # reach out on #help-dev-enablement if you encounter any issues
-    needs:
-      - run-kustomize-build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: manifests
-          path: manifests/
-      - name: install `validate-opslevel-annotations`
-        run: |
-          curl \
-            --location \
-            --silent \
-            https://github.com/utilitywarehouse/manifest-checkers/releases/download/v0.1.0/manifest-checkers_Linux_x86_64.tar.gz \
-          | tar \
-            --directory /usr/local/bin \
-            --extract \
-            --gzip \
-            --file - \
-            validate-opslevel-annotations \
-      - name: Validate Opslevel annotations
-        run: find ./manifests/ -type f -name '*.yaml' | xargs validate-opslevel-annotations

--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -38,7 +38,8 @@ jobs:
         run: |
           set -o pipefail
           mkdir built-manifests/
-          git ls-files -- '*/kustomization.yaml' | xargs kustomize-build-dirs --out-dir built-manifests/
+          git ls-files -- '*/kustomization.yaml' | xargs kustomize-build-dirs --out-dir built-manifests/ --truncate-secrets 2>&1 \
+            | tee build-output
       - name: Check for build errors
         id: check-errors
         run: |

--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -17,13 +17,6 @@ jobs:
           # Fetch both the merge commit GitHub generates for the pull request
           # and both its parents, i.e. the tip of the branch and the tip of main
           fetch-depth: 2
-      #- name: Configure git private access
-      #  # pin to a SHA until things settle and there's a tagged version
-      #  # uses: utilitywarehouse/internal-actions/setup-github-access@setup-github-access/v0.1.0
-      #  uses: utilitywarehouse/internal-actions/setup-github-access@e2b09b2653c47f64ca6d09f6f65122318fbaad0e
-      #  with:
-      #    github-token: ${{ secrets.DEPLOY_GITHUB_TOKEN }}
-      #    github-user: ${{ secrets.DEPLOY_GITHUB_USER }}
       - name: install `kustomize-build-dirs`
         run: |
           curl \

--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -135,3 +135,31 @@ jobs:
         with:
           name: manifests
           path: built-manifests/
+
+  validate-opslevel-annotations:
+    # run some basic checks against the OpsLevel annotations (or lack thereof) in the manifests
+    # powered by https://github.com/utilitywarehouse/dev-enablement-mono/blob/main/cmd/validate-opslevel-annotations/main.go
+    # reach out on #help-dev-enablement if you encounter any issues
+    needs:
+      - run-kustomize-build
+    if: needs.changes.outputs.opslevel-annotations == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: manifests
+          path: manifests/
+      - name: install `validate-opslevel-annotations`
+        run: |
+          curl \
+            --location \
+            --silent \
+            https://github.com/utilitywarehouse/manifest-checkers/releases/download/v0.1.0/manifest-checkers_Linux_x86_64.tar.gz \
+          | tar \
+            --directory /usr/local/bin \
+            --extract \
+            --gzip \
+            --file - \
+            validate-opslevel-annotations \
+      - name: Validate Opslevel annotations
+        run: find ./manifests/ -type f -name '*.yaml' | xargs validate-opslevel-annotations

--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -142,7 +142,6 @@ jobs:
     # reach out on #help-dev-enablement if you encounter any issues
     needs:
       - run-kustomize-build
-    if: needs.changes.outputs.opslevel-annotations == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
       - main
-      - DENA-489
 
 jobs:
   # run `kustomize build` over changed kustomize directories

--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   # run `kustomize build` over changed kustomize directories
-  # powered by https://github.com/utilitywarehouse/dev-enablement-mono/blob/main/cmd/kustomize-build-dirs/main.go
+  # powered by https://github.com/utilitywarehouse/manifest-checkers/tree/main/cmd/kustomize-build-dirs
   # reach out on #help-dev-enablement if you encounter any issues
   run-kustomize-build:
     runs-on: ubuntu-latest
@@ -66,7 +66,6 @@ jobs:
           # checkout the first parent of the merge commit (main)
           # and build against the changes on the current branch
           mkdir root-manifests/
-          pr_head="$(git rev-parse --verify HEAD)"
           main_sha="$(git rev-parse --verify HEAD^1)"
           git -c advice.detachedHead=false checkout --force "$main_sha"
           git ls-files -- '*/kustomization.yaml' \

--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -1,0 +1,146 @@
+name: Check manifests
+on:
+  pull_request:
+    branches:
+      - main
+      - DENA-489
+
+jobs:
+  # run `kustomize build` over changed kustomize directories
+  # powered by https://github.com/utilitywarehouse/dev-enablement-mono/blob/main/cmd/kustomize-build-dirs/main.go
+  # reach out on #help-dev-enablement if you encounter any issues
+  run-kustomize-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Fetch both the merge commit GitHub generates for the pull request
+          # and both its parents, i.e. the tip of the branch and the tip of main
+          fetch-depth: 2
+      - name: Configure git private access
+        # we need SSH access to fetch remove kustomize resources
+        # pin to a SHA until things settle and there's a tagged version
+        # uses: utilitywarehouse/internal-actions/setup-github-access@setup-github-access/v0.1.0
+        uses: utilitywarehouse/internal-actions/setup-github-access@e2b09b2653c47f64ca6d09f6f65122318fbaad0e
+        with:
+          github-token: ${{ secrets.DEPLOY_GITHUB_TOKEN }}
+          github-user: ${{ secrets.DEPLOY_GITHUB_USER }}
+      - name: install `kustomize-build-dirs`
+        run: |
+          curl \
+            --location \
+            --silent \
+            https://github.com/utilitywarehouse/manifest-checkers/releases/download/v0.1.0/manifest-checkers_Linux_x86_64.tar.gz \
+          | tar \
+            --directory /usr/local/bin \
+            --extract \
+            --gzip \
+            --file - \
+            kustomize-build-dirs \
+      - name: Ensure Kustomize
+        run: >-
+          command -v kustomize ||
+          curl --silent --location https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.2.1/kustomize_v5.2.1_linux_amd64.tar.gz |
+          tar zx -C /usr/local/bin
+      - name: Run `kustomize build` across changed directories
+        run: |
+          set -o pipefail
+
+          mkdir built-manifests/
+          git diff --name-only --diff-filter=d HEAD^1 HEAD \
+            | xargs kustomize-build-dirs --out-dir built-manifests/ --truncate-secrets 2>&1 \
+            | tee build-output
+      - name: Check for build errors
+        id: check-errors
+        run: |
+          # grab text between delimiters "---End warnings---"/"---start Warnings---"
+          build_errors="$(awk '$0=="---End warnings---"{d=0} d{print $0} $0=="---start Warnings---"{d=1}' build-output)"
+          if [ -n "$build_errors" ]
+          then
+            # multi-line output https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+            echo "build-errs<<EOF" >> "$GITHUB_OUTPUT"
+            # print lines until the line that takes the total output is over 25000 characters
+            # this is to keep output size small while also not cutting things off mid-line (which can lead to confusing output)
+            awk -v max_length=25000 '{len+=length(); print} len >= max_length {exit(0)}' <<< "${build_errors}" >> "$GITHUB_OUTPUT"
+            echo -e "\n=============================================" >> "$GITHUB_OUTPUT"
+            if [[ ${#build_errors} -gt 25000 ]]
+            then
+              echo -e "\n(Errors output is truncated to 25000 characters)" >> "$GITHUB_OUTPUT"
+            fi
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Run `kustomize build` across files in main
+        run: |
+          set -o pipefail
+
+          # checkout the first parent of the merge commit (main)
+          # and build against the changes on the current branch
+          mkdir root-manifests/
+          pr_head="$(git rev-parse --verify HEAD)"
+          main_sha="$(git rev-parse --verify HEAD^1)"
+          git -c advice.detachedHead=false checkout --force "$main_sha"
+          git diff --name-only --diff-filter=d "$pr_head" "$main_sha" \
+            | xargs kustomize-build-dirs --out-dir root-manifests/ --truncate-secrets
+      - name: Compare changed directories to main
+        id: diff
+        run: |
+          # compare with the manifests built on the current branch
+          diff_output="$(git --no-pager diff --no-index root-manifests/ built-manifests/ || true)"
+          if [ -n "$diff_output" ]
+          then
+            echo "diff-output<<EOF" >> "$GITHUB_OUTPUT"
+            awk -v max_length=25000 '{len+=length(); print} len >= max_length {exit(0)}' <<< "${diff_output}" >> "$GITHUB_OUTPUT"
+            echo -e "\n=============================================" >> "$GITHUB_OUTPUT"
+            if [[ ${#diff_output} -gt 25000 ]]
+            then
+              echo -e "(Diff output is truncated to 25000 characters)" >> "$GITHUB_OUTPUT"
+            fi
+            add=$(echo "$diff_output" | grep -o '\+kind' | wc -l)
+            destroy=$(echo "$diff_output" | grep -o '\-kind' | wc -l)
+            change=$(echo "$diff_output" | grep -o '^@@' | wc -l)
+            echo "k8s objects: $add to add, $destroy to destroy" >> "$GITHUB_OUTPUT"
+            echo "$change changed hunks" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Diff as PR comment
+        if: steps.diff.outputs.diff-output != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: k8s-diff
+          recreate: true
+          message: |
+            Post `kustomize build` diff:
+
+            ```diff
+            ${{ steps.diff.outputs.diff-output }}
+            ```
+      - name: Remove diff as PR comment
+        if: steps.diff.outputs.diff-output == ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: k8s-diff
+          delete: true
+      - name: Warnings as PR comment
+        if: steps.check-errors.outputs.build-errs != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: k8s-warnings
+          recreate: true
+          message: |
+            Warnings found when running `kustomize build` at ${{ github.sha }}:
+
+            ```
+            ${{ steps.check-errors.outputs.build-errs }}
+            ```
+      - name: Remove diff as PR comment
+        if: steps.check-errors.outputs.build-errs == ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: k8s-warnings
+          delete: true
+      - name: Upload manifests
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifests
+          path: built-manifests/

--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -35,11 +35,10 @@ jobs:
           curl --silent --location https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.2.1/kustomize_v5.2.1_linux_amd64.tar.gz |
           tar zx -C /usr/local/bin
       - name: Run `kustomize build` across changed directories
-        run: |
-          set -o pipefail
-          mkdir built-manifests/
-          git ls-files -- '*/kustomization.yaml' | xargs kustomize-build-dirs --out-dir built-manifests/ --truncate-secrets 2>&1 \
-            | tee build-output
+        run: >-
+          git ls-files -- '*/kustomization.yaml'
+          | xargs kustomize-build-dirs --out-dir built-manifests/ --truncate-secrets 2>&1
+          | tee build-output
       - name: Check for build errors
         id: check-errors
         run: |
@@ -61,11 +60,7 @@ jobs:
           fi
       - name: Run `kustomize build` across files in main
         run: |
-          set -o pipefail
-
-          # checkout the first parent of the merge commit (main)
-          # and build against the changes on the current branch
-          mkdir root-manifests/
+          # main is the first parent of the merge commit created by GitHub
           main_sha="$(git rev-parse --verify HEAD^1)"
           git -c advice.detachedHead=false checkout --force "$main_sha"
           git ls-files -- '*/kustomization.yaml' \

--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -2,7 +2,7 @@ name: Check manifests
 on:
   pull_request:
     branches:
-      - main
+      - '*'
 
 jobs:
   # run `kustomize build` over changed kustomize directories
@@ -69,7 +69,7 @@ jobs:
           pr_head="$(git rev-parse --verify HEAD)"
           main_sha="$(git rev-parse --verify HEAD^1)"
           git -c advice.detachedHead=false checkout --force "$main_sha"
-          git diff --name-only --diff-filter=d "$pr_head" "$main_sha" \
+          git ls-files -- '*/kustomization.yaml' \
             | xargs kustomize-build-dirs --out-dir root-manifests/ --truncate-secrets
       - name: Compare changed directories to main
         id: diff

--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -37,11 +37,8 @@ jobs:
       - name: Run `kustomize build` across changed directories
         run: |
           set -o pipefail
-
           mkdir built-manifests/
-          git diff --name-only --diff-filter=d HEAD^1 HEAD \
-            | xargs kustomize-build-dirs --out-dir built-manifests/ --truncate-secrets 2>&1 \
-            | tee build-output
+          git ls-files -- '*/kustomization.yaml' | xargs kustomize-build-dirs --out-dir built-manifests/
       - name: Check for build errors
         id: check-errors
         run: |

--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -17,14 +17,13 @@ jobs:
           # Fetch both the merge commit GitHub generates for the pull request
           # and both its parents, i.e. the tip of the branch and the tip of main
           fetch-depth: 2
-      - name: Configure git private access
-        # we need SSH access to fetch remove kustomize resources
-        # pin to a SHA until things settle and there's a tagged version
-        # uses: utilitywarehouse/internal-actions/setup-github-access@setup-github-access/v0.1.0
-        uses: utilitywarehouse/internal-actions/setup-github-access@e2b09b2653c47f64ca6d09f6f65122318fbaad0e
-        with:
-          github-token: ${{ secrets.DEPLOY_GITHUB_TOKEN }}
-          github-user: ${{ secrets.DEPLOY_GITHUB_USER }}
+      #- name: Configure git private access
+      #  # pin to a SHA until things settle and there's a tagged version
+      #  # uses: utilitywarehouse/internal-actions/setup-github-access@setup-github-access/v0.1.0
+      #  uses: utilitywarehouse/internal-actions/setup-github-access@e2b09b2653c47f64ca6d09f6f65122318fbaad0e
+      #  with:
+      #    github-token: ${{ secrets.DEPLOY_GITHUB_TOKEN }}
+      #    github-user: ${{ secrets.DEPLOY_GITHUB_USER }}
       - name: install `kustomize-build-dirs`
         run: |
           curl \

--- a/elasticsearch/example/kustomization.yaml
+++ b/elasticsearch/example/kustomization.yaml
@@ -38,4 +38,4 @@ patches:
         value: "4Gi"
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: "8Gi"
+        value: "6Gi"

--- a/es-topic-indexer/example/kustomization.yaml
+++ b/es-topic-indexer/example/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   #- ssh://github.com/utilitywarehouse/shared-kustomize-bases//es-topic-indexer/manifests?ref=v0.0.0
   - ../manifests
+  - kafka-certificate.yaml
 
 
 # Add prefix to name
@@ -11,4 +12,3 @@ namePrefix: sample-event-
 
 patches:
   - path: indexer-params.yaml
-  - path: kafka-certificate.yaml


### PR DESCRIPTION
Diff between this action and action from  kubernetes-manifests:
```diff
5c5
5c5
<       - master
---
>       - '*'
9c9
<   # powered by https://github.com/utilitywarehouse/dev-enablement-mono/blob/main/cmd/kustomize-build-dirs/main.go
---
>   # powered by https://github.com/utilitywarehouse/manifest-checkers/tree/main/cmd/kustomize-build-dirs
18c18
<           # and both its parents, i.e. the tip of the branch and the tip of master
---
>           # and both its parents, i.e. the tip of the branch and the tip of main
20,26d19
<       - name: Configure git private access
<         # we need SSH access to fetch remove kustomize resources
<         # pin to a SHA until things settle and there's a tagged version
<         # uses: utilitywarehouse/internal-actions/setup-github-access@setup-github-access/v0.1.0
<         uses: utilitywarehouse/internal-actions/setup-github-access@e2b09b2653c47f64ca6d09f6f65122318fbaad0e
<         with:
<           private-ssh-key: ${{ secrets.UW_INFRA_USER_SSH_KEY }}
45,51c38,41
<         run: |
<           set -o pipefail
< 
<           mkdir built-manifests/
<           git diff --name-only --diff-filter=d HEAD^1 HEAD \
<             | xargs kustomize-build-dirs --out-dir built-manifests/ --truncate-secrets 2>&1 \
<             | tee build-output
---
>         run: >-
>           git ls-files -- '*/kustomization.yaml'
>           | xargs kustomize-build-dirs --out-dir built-manifests/ --truncate-secrets 2>&1
>           | tee build-output
71c61
<       - name: Run `kustomize build` across files in master
---
>       - name: Run `kustomize build` across files in main
73,81c63,66
<           set -o pipefail
< 
<           # checkout the first parent of the merge commit (master)
<           # and build against the changes on the current branch
<           mkdir root-manifests/
<           pr_head="$(git rev-parse --verify HEAD)"
<           master_sha="$(git rev-parse --verify HEAD^1)"
<           git -c advice.detachedHead=false checkout --force "$master_sha"
<           git diff --name-only --diff-filter=d "$pr_head" "$master_sha" \
---
>           # main is the first parent of the merge commit created by GitHub
>           main_sha="$(git rev-parse --verify HEAD^1)"
>           git -c advice.detachedHead=false checkout --force "$main_sha"
>           git ls-files -- '*/kustomization.yaml' \
83c68
<       - name: Compare changed directories to master
---
>       - name: Compare changed directories to main
145,193d129
< 
<   changes:
<     # further filter changes paths to run further optional checks
<     runs-on: ubuntu-latest
<     permissions:
<       pull-requests: read
<     outputs:
<       opslevel-annotations: ${{ steps.filter.outputs.opslevel-annotations }}
<     steps:
<       - uses: dorny/paths-filter@v3
<         id: filter
<         with:
<           filters: |
<             # changes under here will also be run through 'validate-opslevel-annotations'
<             opslevel-annotations:
<               - '**/auth/**'
<               - '**/auth-customer/**'
<               - '**/dev-enablement/**'
<               - '**/data-infra/**'
<               - '**/pubsub/**'
< 
<   validate-opslevel-annotations:
<     # run some basic checks against the OpsLevel annotations (or lack thereof) in the manifests
<     # powered by https://github.com/utilitywarehouse/dev-enablement-mono/blob/main/cmd/validate-opslevel-annotations/main.go
<     # reach out on #help-dev-enablement if you encounter any issues
<     needs:
<       - changes
<       - run-kustomize-build
<     if: needs.changes.outputs.opslevel-annotations == 'true'
<     runs-on: ubuntu-latest
<     steps:
<       - uses: actions/download-artifact@v4
<         with:
<           name: manifests
<           path: manifests/
<       - name: install `validate-opslevel-annotations`
<         run: |
<           curl \
<             --location \
<             --silent \
<             https://github.com/utilitywarehouse/manifest-checkers/releases/download/v0.1.0/manifest-checkers_Linux_x86_64.tar.gz \
<           | tar \
<             --directory /usr/local/bin \
<             --extract \
<             --gzip \
<             --file - \
<             validate-opslevel-annotations \
<       - name: Validate Opslevel annotations
<         run: find ./manifests/ -type f -name '*.yaml' | xargs validate-opslevel-annotations

```