### PR TITLE
[DENA-580] move cockroachdb-manifests to shared-kustomize-bases

### DIFF
--- a/cockroachdb/CERT_MANAGER_README.md
+++ b/cockroachdb/CERT_MANAGER_README.md
@@ -1,0 +1,10 @@
+# Certificates
+
+In order to secure the communication between CRDB nodes and clients we need to generate three certificates:
+- CA Certifiace - used to sign node and client certificates
+- Node Certificate - used to allow nodes establishing a connection to each other. The Node Certificate is being shared between all nodes
+- Client Certificate - used by the init and backup jobs to connect to CRDB
+
+All necessary manifests are in the [base-cert-manager](https://github.com/utilitywarehouse/cockroachdb-manifests/tree/master/base-cert-manager) directory, however, you will need to manually update
+`node` Certificate manifest patch to specify the name of the namespace you are deploying CRDB to.
+In case if you want to deploy more than 3 replicas of CRDB node, you will also need to update the same patch file.

--- a/cockroachdb/CFSSL_README.md
+++ b/cockroachdb/CFSSL_README.md
@@ -1,0 +1,61 @@
+# CFSSL
+
+"CFSSL is CloudFlare's PKI/TLS swiss army knife". This base requires cfssl and depends on the API server
+to sign certificates and retrieve the Certificate Authority it will trust. CFSSL provide a
+[docker container](https://hub.docker.com/r/cfssl/cfssl/) which can be deployed in Kubernetes.
+
+## Certificates
+
+- The base relies on [docker-cockroach-cfssl-certs](https://github.com/utilitywarehouse/docker-cockroach-cfssl-certs).
+It is executed via an init container, acquiring certificates on pod start.
+- The container relies on the CFSSL AuthSign endpoint and passes a CSR (Certificate Signature Request) and token.
+- It uses the same container as a sidecar to refresh certificates when they are due to expire and sends a `SIGHUP` to the
+  Cockroach process to inform it to reload the certificates see [docs](https://www.cockroachlabs.com/docs/stable/rotate-certificates.html)
+- To send a signal to a different container they require a shared process namespace,
+  see [docs](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/).
+  - This will require configuring kubernetes to grant the `SYS_PTRACE` capability to the container.
+  - See [this](https://github.com/utilitywarehouse/kubernetes-manifests/pull/75092) PR for example (yes, access is given per namespace).
+
+### Generating Certificates
+
+To configure the certificate authority you will need to generate a hex encoded access key, a self signed CA certificate and key for it and store these in kubernetes as secrets. To generate a certificate first create a json file with your configuration (changing the values as necessary):
+
+``` json
+{
+  "CN": "Utility Warehouse CA",
+  "key": {
+    "algo": "ecdsa",
+    "size": 521
+  },
+  "ca": {
+    "expiry": "17520h"
+  }
+}
+```
+Note that this will expire in 2 years
+
+then run the `cfssl` command to generate certificates, `cfssl gencert -initca <your-config-file>.json | cfssljson -bare ca`. The command will generate 3 files `ca.pem`, `ca-key.pem` and `ca.csr`. You will not need the `cs.csr` file to configure cockroach.
+
+finally you can generate a hex encoded access key with
+``` shell
+hexdump -n 16 -e '4/4 "%08X" 1 "\n"' /dev/random
+```
+
+### Generate new certificate
+When CA certificate is about to expire you can generate new certificate using
+the same key by running the following command.
+
+`cfssl gencert -ca-key=ca-key.pem -initca ca-csr.json | cfssljson -bare ca`
+
+Here `ca-csr.json` is the same file as before and `ca-key.pem` is the old
+generated key. You can then delete the `ca-certs` secret and recreate it
+with the same command as before.
+
+Without requiring the `ca-csr.json`, you can renew the certificate with
+`cfssl gencert -renewca -ca ca-certs-ca.pem -ca-key ca-certs-ca-key.pem | cfssljson -bare ca`
+
+Once the secret is updated you should restart the pods of the CA service
+to make them use the new certificate. Afterwards, you should restart all 
+services that use certificates signed by this CA, so that they can fetch
+the new CA certificate. As we are using the same key the certificates signed
+by the CA will appear to be signed by both the old CA certificate and the new one.

--- a/cockroachdb/CODEOWNERS
+++ b/cockroachdb/CODEOWNERS
@@ -1,0 +1,1 @@
+* @utilitywarehouse/dev-enablement

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -1,0 +1,81 @@
+# cockroachdb-manifests
+
+This is a Kustomization base for deploying CockroachDB to a Kubernetes cluster. The base depends on [cert-manager](https://github.com/cert-manager/cert-manager) for generating and renewing certificates to secure communication between nodes and clients.
+
+## Deployment
+
+To deploy a cockroachdb cluster in your namespace you will need to setup a `kustomization.yaml` file that will use the bases defined here with your own configuration layered over the top. There is an [examples](./examples/) folder that can be used as a starting point. By filling in the missing pieces (e.g. certs, backup config, etc) you should get a running CRDB cluster with periodic backups to S3 and AWS creds injected via [vault](https://github.com/utilitywarehouse/documentation/blob/master/infra/vault/vault-aws.md) (assumes an existing vault setup).
+
+### Single namespace - multiple CockroachDB clusters
+
+While the preference is to have a single CockroachDB cluster per namespace, in some cases this isn't ideal. 
+
+An example of this is in the Energy team where they have recently split into three squads but currently still share use of the `energy-platform` namespace. 
+
+In order to deploy multiple CockroachDB clusters within a single namespace whilst avoiding naming conflicts we can make use of the `namePrefix` and/or `nameSuffix` ability of Kustomize. 
+This will automagically update the names of resources within a Kustomization as well as the selectors and labels. 
+
+One part of this that Kustomize is not able to help with is with the CockroachDB specific commands that are used to create and join nodes to the cluster. 
+For this two environment variables have been added `COCKROACH_INIT_HOST` and `COCKROACH_JOIN_STRING`. 
+
+- `COCKROACH_INIT_HOST` is used by the `init-job.yaml` manifest to initialise the first node in the cluster
+- `COCKROACH_JOIN_STRING` is in the `statefulset.yaml` manifest to define which nodes will be joining the cluster. 
+
+There are sensible defaults for these environment variables to ensure that a single cluster within a namespace can be brought up without overriding any environment variables. 
+
+
+### Versioning
+
+This repo uses tags to manage versions, these tags have two components:
+
+  - The version of the `cockroachdb/cockroach` image the manifests are using
+  - An internal version to track changes to anything besides the version of
+    CockroachDB
+
+These tags are of the form `<cockroachdb-version>-<internal-version>`, for
+example: `v23.1.10-2` is the 2nd internal version of these manifests supporting
+`cockroachdb/cockroachv:23.1.10`
+
+### Configuration
+Cockroach DB requires some base configuration that can be overridden. (An example is below)
+- Note: `cockroach.host` and `cockroach.port` are required by the backup job.
+```
+cockroach.host=cockroachdb-proxy
+cockroach.port=26257
+```
+
+#### CockroachDB
+
+You can configure `--cache` and `--max-sql-memory` cockroachdb flags via
+following envvars: `CACHE` and `MAX_SQL_MEMORY`.
+
+### Client
+
+- The base provides a client deployment that bootstraps the Cockroach sql command.
+- The client deployment is useful for debugging issues and communicating with Cockroach.
+- An example command for starting a sql shell is `kubectl exec -it deployment/cockroachdb-client -c cockroachdb-client -- cockroach sql`
+
+### Admin UI
+
+In order to access admin UI, Port forward port 8080 on one of the cockroachdb- pods,
+then navigate to https://localhost:8080/
+
+### DB Console
+
+CockroachDB has a DB console [user interface](https://www.cockroachlabs.com/docs/stable/ui-overview.html).
+To log into the DB console you will require a database user.
+This can be achieved by:
+- Start a SQL shell using the client `kubectl exec -it deployment/cockroachdb-client -c cockroachdb-client -- cockroach sql`
+  - You may need to change the replica count of the client (see above)
+- Create a user using SQL `CREATE USER foo WITH PASSWORD 'changeme';`
+- Assign admin role to the user with the SQL command `GRANT admin TO foo;`
+  - This allows full access within the UI.
+- Port forward any node `kubectl port-forward cockroachdb-0 8080`
+- Use a browser to navigate to https://localhost:8080.
+- It will warn you that the certificate is not trusted, this is expected.
+
+### Architecture
+We recommend creating one instance of CockroachDB cluster per namespace instead of creating new cluster instance
+for each of applications.
+Data can be separated by creating different databases, and having one, bigger cluster instead of multiple smaller ones
+reduces infrastructure costs and maintenance overhead.

--- a/cockroachdb/base-cert-manager/backup-init-job.yaml
+++ b/cockroachdb/base-cert-manager/backup-init-job.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cockroach-backup-init
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
+  template:
+    spec:
+      containers:
+        - name: backup-init
+          image: cockroachdb
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/bin/bash"
+            - "/opt/scripts/backup-bootstrap.sh"
+          env:
+            - name: COCKROACH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: cockroach
+                  key: cockroach.host
+            - name: COCKROACH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: cockroach
+                  key: cockroach.port
+            - name: COCKROACH_CERTS_DIR
+              value: "/cockroach-certs/"
+            - name: BACKUP_SCHEDULE
+              valueFrom:
+                configMapKeyRef:
+                  name: cockroach.backup.config
+                  key: schedule
+            - name: BACKUP_DESTINATION_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: cockroach.backup.config
+                  key: destination.url
+          volumeMounts:
+            - name: client-certs
+              mountPath: /cockroach-certs
+            - name: cockroachdb-scripts
+              mountPath: /opt/scripts
+              readOnly: true
+          resources:
+            requests:
+              cpu: 0
+              memory: 128Mi
+            limits:
+              cpu: 1
+              memory: 512Mi
+      restartPolicy: OnFailure
+      volumes:
+        - name: client-certs
+          emptyDir: {}
+        - name: cockroachdb-scripts
+          configMap:
+            name: cockroachdb-scripts

--- a/cockroachdb/base-cert-manager/budget.yaml
+++ b/cockroachdb/base-cert-manager/budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cockroachdb-budget
+  labels:
+    app: cockroachdb
+spec:
+  selector:
+    matchLabels:
+      app: cockroachdb
+  maxUnavailable: 1

--- a/cockroachdb/base-cert-manager/certificates.yaml
+++ b/cockroachdb/base-cert-manager/certificates.yaml
@@ -1,0 +1,63 @@
+# https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cockroachdb-selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cockroachdb-ca
+spec:
+  isCA: true
+  commonName: cockroachdb-ca
+  dnsNames:
+    - cockroachdb-ca
+  secretName: cockroachdb-ca
+  issuerRef:
+    name: cockroachdb-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cockroachdb-ca-issuer
+spec:
+  ca:
+    secretName: cockroachdb-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: node
+spec:
+  issuerRef:
+    name: cockroachdb-ca-issuer
+    kind: Issuer
+  commonName: node
+  dnsNames:
+    - 127.0.0.1
+    - localhost
+    - cockroachdb-0.cockroachdb
+    - cockroachdb-1.cockroachdb
+    - cockroachdb-2.cockroachdb
+  secretName: cockroachdb.node
+  usages:
+    - server auth
+    - client auth
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: client
+spec:
+  issuerRef:
+    name: ca-issuer
+    kind: Issuer
+  commonName: root
+  secretName: cockroachdb.client.root
+  usages:
+    - client auth

--- a/cockroachdb/base-cert-manager/client.yaml
+++ b/cockroachdb/base-cert-manager/client.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: &app cockroachdb-client
+  annotations:
+    "app.uw.systems/description": "Used to connect and query the cockroachdb databases."
+    "app.uw.systems/repos.cockroachdb-manifests": "https://github.com/utilitywarehouse/cockroachdb-manifests"
+    "app.uw.systems/tier": "tier_4"
+    "app.uw.systems/tags.oss": "true"
+    "secret.reloader.stakater.com/reload": "cockroachdb.client.root"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: *app
+  template:
+    metadata:
+      name: *app
+      labels:
+        app: *app
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: cockroachdb-client
+          image: cockroachdb
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              sleep infinity & PID=$!
+              trap "kill $PID" TERM
+              wait
+              echo "shutting down..."
+          env:
+            - name: COCKROACH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: cockroach
+                  key: cockroach.host
+            - name: COCKROACH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: cockroach
+                  key: cockroach.port
+            - name: COCKROACH_CERTS_DIR
+              value: "/cockroach/cockroach-certs"
+          resources:
+            requests:
+              cpu: 0m
+              memory: 16Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+          volumeMounts:
+            - name: client-certs
+              mountPath: /cockroach/cockroach-certs
+      volumes:
+        - name: client-certs
+          secret:
+            secretName: cockroachdb.client.root
+            defaultMode: 256

--- a/cockroachdb/base-cert-manager/init-job.yaml
+++ b/cockroachdb/base-cert-manager/init-job.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cockroach-init
+  labels:
+    app: cockroachdb
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      containers:
+        - name: cluster-init
+          image: cockroachdb
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: client-certs
+              mountPath: /cockroach/cockroach-certs
+          env:
+            - name: COCKROACH_INIT_HOST
+              value: cockroachdb-0.cockroachdb
+          command:
+            - "/bin/bash"
+            - "-c"
+            - "/cockroach/cockroach init --certs-dir=/cockroach/cockroach-certs --host=$(COCKROACH_INIT_HOST) --port=26357 2>&1 | grep 'initialized'"
+          resources:
+            requests:
+              cpu: 0
+              memory: 128Mi
+            limits:
+              cpu: 1
+              memory: 512Mi
+      restartPolicy: OnFailure
+      volumes:
+        - name: client-certs
+          secret:
+            secretName: cockroachdb.client.root
+            defaultMode: 256

--- a/cockroachdb/base-cert-manager/kustomization.yaml
+++ b/cockroachdb/base-cert-manager/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+images:
+  - name: cockroachdb
+    newName: cockroachdb/cockroach
+    newTag: v23.2.2
+
+resources:
+  - certificates.yaml
+  - client.yaml
+  - service.yaml
+  - statefulset.yaml
+  - budget.yaml
+  - init-job.yaml
+  - backup-init-job.yaml
+  - scripts.yaml

--- a/cockroachdb/base-cert-manager/scripts.yaml
+++ b/cockroachdb/base-cert-manager/scripts.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cockroachdb-scripts
+data:
+  user-schema-bootstrap.sh: |
+    #!/bin/bash
+    set -e
+
+    if [ -z "$DB_USER" ]; then
+        echo "DB_USER envvar is not set"
+        exit 1
+    fi
+
+    if [ -z "$DB_NAME" ]; then
+        echo "DB_NAME envvar not set"
+        exit 1
+    fi
+
+    SQL_CMD="/cockroach/cockroach -d system sql" > /dev/null
+
+    $SQL_CMD << EOF
+      CREATE USER IF NOT EXISTS $DB_USER;
+      CREATE DATABASE IF NOT EXISTS $DB_NAME;
+      GRANT ALL ON DATABASE $DB_NAME TO $DB_USER;
+      GRANT ALL ON TABLE $DB_NAME.* TO $DB_USER;
+    EOF
+
+  backup-bootstrap.sh: |
+    #!/bin/bash
+    set -e
+
+    if [ -z "$BACKUP_SCHEDULE" ]; then
+        echo "BACKUP_SCHEDULE envvar is not set"
+        exit 1
+    fi
+
+    if [ -z "$BACKUP_DESTINATION_URL" ]; then
+        echo "BACKUP_DESTINATION_URL envvar is not set"
+        exit 1
+    fi
+
+    SQL_CMD="/cockroach/cockroach sql" > /dev/null
+
+    $SQL_CMD << EOF
+      BEGIN;
+      -- create a new schedule
+      CREATE SCHEDULE IF NOT EXISTS cluster_backup
+        FOR BACKUP INTO '$BACKUP_DESTINATION_URL'
+          RECURRING '$BACKUP_SCHEDULE'
+          FULL BACKUP ALWAYS
+          WITH SCHEDULE OPTIONS ignore_existing_backups;
+      COMMIT;
+    EOF

--- a/cockroachdb/base-cert-manager/service.yaml
+++ b/cockroachdb/base-cert-manager/service.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # This service is meant to be used by clients of the database. It exposes a ClusterIP that will
+  # automatically load balance connections to the different database pods.
+  name: cockroachdb-proxy
+  labels:
+    app: cockroachdb
+spec:
+  ports:
+  # The main port, serves Postgres-flavor SQL, for clients
+  - port: 26257
+    targetPort: 26257
+    name: sql
+  # The port used for node-node RPC connections
+  - port: 26357
+    targetPort: 26357
+    name: rpc
+  # UI as well as health and debug endpoints
+  - port: 8001
+    targetPort: 8001
+    name: http
+  selector:
+    app: cockroachdb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # This service only exists to create DNS entries for each pod in the stateful
+  # set such that they can resolve each other's IP addresses. It does not
+  # create a load-balanced ClusterIP and should not be used directly by clients
+  # in most circumstances.
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+  annotations:
+    # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "_status/vars"
+    prometheus.io/port: "8001"
+    uw.health.aggregator.enable: "false"
+spec:
+  ports:
+  - port: 26257
+    targetPort: 26257
+    name: sql
+  - port: 26357
+    targetPort: 26357
+    name: rpc
+  - port: 8001
+    targetPort: 8001
+    name: http
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other CockroachDB pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector:
+    app: cockroachdb

--- a/cockroachdb/base-cert-manager/statefulset.yaml
+++ b/cockroachdb/base-cert-manager/statefulset.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+  annotations:
+    "app.uw.systems/description": "Used to store data projections of events in multiple services."
+    "app.uw.systems/tier": "tier_1"
+    "app.uw.systems/repos.cockroachdb-manifests": "https://github.com/utilitywarehouse/cockroachdb-manifests"
+    "app.uw.systems/tags.oss": "true"
+    "secret.reloader.stakater.com/reload": "cockroachdb.node"
+spec:
+  serviceName: cockroachdb
+  replicas: 3
+  selector:
+    matchLabels:
+      app: cockroachdb
+  template:
+    metadata:
+      labels:
+        app: cockroachdb
+        policy.semaphore.uw.io/name: cockroachdb
+    spec:
+      serviceAccountName: cockroachdb
+      shareProcessNamespace: true
+      # No pre-stop hook is required, a SIGTERM plus some time is all that's
+      # needed for graceful shutdown of a node.
+      terminationGracePeriodSeconds: 60
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - cockroachdb
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: cockroachdb
+          image: cockroachdb
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/bin/bash"
+            - "-ecx"
+            # The use of qualified `hostname -f` is crucial:
+            # Other nodes aren't able to look up the unqualified hostname.
+            - >
+              exec /cockroach/cockroach start
+              --logtostderr=WARNING
+              --certs-dir /cockroach/cockroach-certs
+              --listen-addr=:26357
+              --sql-addr=:26257
+              --advertise-addr $(hostname -f)
+              --http-addr 0.0.0.0
+              --join $(COCKROACH_JOIN_STRING)
+              --cache $(CACHE)
+              --max-sql-memory $(MAX_SQL_MEMORY)
+          env:
+            - name: COCKROACH_CHANNEL
+              value: kubernetes-secure
+            - name: COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING
+              value: "true"
+            - name: CACHE
+              value: 256MB
+            - name: MAX_SQL_MEMORY
+              value: 256MB
+            - name: COCKROACH_JOIN_STRING
+              value: cockroachdb-0.cockroachdb:26257,cockroachdb-0.cockroachdb:26357,cockroachdb-1.cockroachdb:26257,cockroachdb-1.cockroachdb:26357,cockroachdb-2.cockroachdb:26257,cockroachdb-2.cockroachdb:26357
+          ports:
+            - containerPort: 26257
+              name: sql
+            - containerPort: 26357
+              name: rpc
+            - containerPort: 8080
+              name: http
+          livenessProbe:
+            httpGet:
+              path: "/health"
+              port: http
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: "/health?ready=1"
+              port: http
+              scheme: HTTPS
+            initialDelaySeconds: 60
+            periodSeconds: 5
+            failureThreshold: 2
+          volumeMounts:
+            - name: datadir
+              mountPath: /cockroach/cockroach-data
+            - name: certs
+              mountPath: /cockroach/cockroach-certs
+          resources:
+            requests:
+              cpu: "0m"
+              memory: "768Mi"
+            limits:
+              cpu: "4000m"
+              memory: "1Gi"
+      volumes:
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: certs
+          secret:
+            secretName: cockroachdb.node
+            defaultMode: 256
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 10Gi

--- a/cockroachdb/base/backup-init-job.yaml
+++ b/cockroachdb/base/backup-init-job.yaml
@@ -1,0 +1,89 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cockroach-backup-init
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
+  template:
+    spec:
+      initContainers:
+      - name: init-certs
+        image: cockroach-cfssl-certs
+        imagePullPolicy: Always
+        command: ["cockroach-certs"]
+        env:
+        - name: CERTIFICATE_TYPE
+          value: "client"
+        - name: USER
+          value: "root"
+        - name: CERTS_DIR
+          value: "/cockroach-certs"
+        - name: CA_PROFILE
+          valueFrom:
+            configMapKeyRef:
+              name: ca.config
+              key: ca.client.profile
+        - name: CA_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              name: ca.config
+              key: ca.endpoint
+        - name: CA_AUTH_KEY
+          valueFrom:
+            secretKeyRef:
+              name: ca.auth
+              key: key
+        volumeMounts:
+        - name: client-certs
+          mountPath: /cockroach-certs
+      containers:
+      - name: backup-init
+        image: cockroachdb
+        imagePullPolicy: IfNotPresent
+        command:
+        - "/bin/bash"
+        - "/opt/scripts/backup-bootstrap.sh"
+        env:
+        - name: COCKROACH_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: cockroach
+              key: cockroach.host
+        - name: COCKROACH_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: cockroach
+              key: cockroach.port
+        - name: COCKROACH_CERTS_DIR
+          value: "/cockroach-certs/"
+        - name: BACKUP_SCHEDULE
+          valueFrom:
+            configMapKeyRef:
+              name: cockroach.backup.config
+              key: schedule
+        - name: BACKUP_DESTINATION_URL
+          valueFrom:
+            configMapKeyRef:
+              name: cockroach.backup.config
+              key: destination.url
+        volumeMounts:
+        - name: client-certs
+          mountPath: /cockroach-certs
+        - name: cockroachdb-scripts
+          mountPath: /opt/scripts
+          readOnly: true
+        resources:
+          requests:
+            cpu: 0
+            memory: 128Mi
+          limits:
+            cpu: 1 
+            memory: 512Mi
+      restartPolicy: OnFailure
+      volumes:
+      - name: client-certs
+        emptyDir: {}
+      - name: cockroachdb-scripts
+        configMap:
+          name: cockroachdb-scripts

--- a/cockroachdb/base/budget.yaml
+++ b/cockroachdb/base/budget.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cockroachdb-budget
+  labels:
+    app: cockroachdb
+spec:
+  selector:
+    matchLabels:
+      app: cockroachdb
+  maxUnavailable: 1

--- a/cockroachdb/base/client.yaml
+++ b/cockroachdb/base/client.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: &app cockroachdb-client
+  annotations:
+    "app.uw.systems/description": "Used to connect and query the cockroachdb databases."
+    "app.uw.systems/repos.cockroachdb-manifests": "https://github.com/utilitywarehouse/cockroachdb-manifests"
+    "app.uw.systems/tier": "tier_4"
+    "app.uw.systems/tags.oss": "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: *app
+  template:
+    metadata:
+      name: *app
+      labels:
+        app: *app
+    spec:
+      terminationGracePeriodSeconds: 60
+      initContainers:
+        - name: init-certs
+          image: cockroach-cfssl-certs
+          command: ["cockroach-certs"]
+          env:
+            - name: CERTIFICATE_TYPE
+              value: "client"
+            - name: USER
+              value: "root"
+            - name: CERTS_DIR
+              value: "/cockroach-certs"
+            - name: CA_PROFILE
+              valueFrom:
+                configMapKeyRef:
+                  name: ca.config
+                  key: ca.node.profile
+            - name: CA_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                  name: ca.config
+                  key: ca.endpoint
+            - name: CA_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ca.auth
+                  key: key
+          volumeMounts:
+            - name: client-certs
+              mountPath: /cockroach-certs
+      containers:
+        - name: cockroachdb-client
+          image: cockroachdb
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              sleep infinity & PID=$!
+              trap "kill $PID" TERM
+              wait
+              echo "shutting down..."
+          env:
+            - name: COCKROACH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: cockroach
+                  key: cockroach.host
+            - name: COCKROACH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: cockroach
+                  key: cockroach.port
+            - name: COCKROACH_CERTS_DIR
+              value: "/cockroach-certs"
+          resources:
+            requests:
+              cpu: 0m
+              memory: 16Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+          volumeMounts:
+            - name: client-certs
+              mountPath: /cockroach-certs
+        - name: certs-refresh
+          image: cockroach-cfssl-certs
+          command: ["cockroach-certs", "refresh"]
+          env:
+            - name: CERTIFICATE_TYPE
+              value: "client"
+            - name: USER
+              value: "root"
+            - name: CERTS_DIR
+              value: "/cockroach-certs"
+            - name: TARGET_PROC_COMMAND
+              value: ""
+            - name: CA_PROFILE
+              valueFrom:
+                configMapKeyRef:
+                  name: ca.config
+                  key: ca.node.profile
+            - name: CA_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                  name: ca.config
+                  key: ca.endpoint
+            - name: CA_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ca.auth
+                  key: key
+          volumeMounts:
+            - name: client-certs
+              mountPath: /cockroach-certs
+      volumes:
+        - name: client-certs
+          emptyDir: { }

--- a/cockroachdb/base/init-job.yaml
+++ b/cockroachdb/base/init-job.yaml
@@ -1,0 +1,65 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cockroach-init
+  labels:
+    app: cockroachdb
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      initContainers:
+      - name: init-certs
+        image: cockroach-cfssl-certs
+        imagePullPolicy: Always
+        command: ["cockroach-certs"]
+        env:
+        - name: CERTIFICATE_TYPE
+          value: "client"
+        - name: USER
+          value: "root"
+        - name: CERTS_DIR
+          value: "/cockroach-certs"
+        - name: CA_PROFILE
+          valueFrom:
+            configMapKeyRef:
+              name: ca.config
+              key: ca.client.profile
+        - name: CA_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              name: ca.config
+              key: ca.endpoint
+        - name: CA_AUTH_KEY
+          valueFrom:
+            secretKeyRef:
+              name: ca.auth
+              key: key
+        volumeMounts:
+        - name: client-certs
+          mountPath: /cockroach-certs
+      containers:
+      - name: cluster-init
+        image: cockroachdb
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: client-certs
+          mountPath: /cockroach-certs
+        env:
+        - name: COCKROACH_INIT_HOST
+          value: cockroachdb-0.cockroachdb
+        command:
+        - "/bin/bash"
+        - "-c"
+        - "/cockroach/cockroach init --certs-dir=/cockroach-certs --host=$(COCKROACH_INIT_HOST) --port=26357 2>&1 | grep 'initialized'"
+        resources:
+          requests:
+            cpu: 0
+            memory: 128Mi
+          limits:
+            cpu: 1
+            memory: 512Mi
+      restartPolicy: OnFailure
+      volumes:
+      - name: client-certs
+        emptyDir: {}

--- a/cockroachdb/base/kustomization.yaml
+++ b/cockroachdb/base/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+images:
+  - name: cockroachdb
+    newName: cockroachdb/cockroach
+    newTag: v23.2.2
+  - name: cockroach-cfssl-certs
+    newName: quay.io/utilitywarehouse/cockroach-cfssl-certs
+    newTag: latest
+
+resources:
+  - client.yaml
+  - service.yaml
+  - statefulset.yaml
+  - budget.yaml
+  - init-job.yaml
+  - backup-init-job.yaml
+  - scripts.yaml

--- a/cockroachdb/base/scripts.yaml
+++ b/cockroachdb/base/scripts.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cockroachdb-scripts
+data:
+  user-schema-bootstrap.sh: |
+    #!/bin/bash
+    set -e
+
+    if [ -z "$DB_USER" ]; then
+        echo "DB_USER envvar is not set"
+        exit 1
+    fi
+
+    if [ -z "$DB_NAME" ]; then
+        echo "DB_NAME envvar not set"
+        exit 1
+    fi
+
+    SQL_CMD="/cockroach/cockroach -d system sql" > /dev/null
+
+    $SQL_CMD << EOF
+      CREATE USER IF NOT EXISTS $DB_USER;
+      CREATE DATABASE IF NOT EXISTS $DB_NAME;
+      GRANT ALL ON DATABASE $DB_NAME TO $DB_USER;
+      GRANT ALL ON TABLE $DB_NAME.* TO $DB_USER;
+    EOF
+
+  backup-bootstrap.sh: |
+    #!/bin/bash
+    set -e
+
+    if [ -z "$BACKUP_SCHEDULE" ]; then
+        echo "BACKUP_SCHEDULE envvar is not set"
+        exit 1
+    fi
+
+    if [ -z "$BACKUP_DESTINATION_URL" ]; then
+        echo "BACKUP_DESTINATION_URL envvar is not set"
+        exit 1
+    fi
+
+    SQL_CMD="/cockroach/cockroach sql" > /dev/null
+
+    $SQL_CMD << EOF
+      BEGIN;
+      -- create a new schedule
+      CREATE SCHEDULE IF NOT EXISTS cluster_backup
+        FOR BACKUP INTO '$BACKUP_DESTINATION_URL'
+          RECURRING '$BACKUP_SCHEDULE'
+          FULL BACKUP ALWAYS
+          WITH SCHEDULE OPTIONS ignore_existing_backups;
+      COMMIT;
+    EOF

--- a/cockroachdb/base/service.yaml
+++ b/cockroachdb/base/service.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # This service is meant to be used by clients of the database. It exposes a ClusterIP that will
+  # automatically load balance connections to the different database pods.
+  name: cockroachdb-proxy
+  labels:
+    app: cockroachdb
+spec:
+  ports:
+  # The main port, serves Postgres-flavor SQL, for clients
+  - port: 26257
+    targetPort: 26257
+    name: sql
+  # The port used for node-node RPC connections
+  - port: 26357
+    targetPort: 26357
+    name: rpc
+  # UI as well as health and debug endpoints
+  - port: 8001
+    targetPort: 8001
+    name: http
+  selector:
+    app: cockroachdb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # This service only exists to create DNS entries for each pod in the stateful
+  # set such that they can resolve each other's IP addresses. It does not
+  # create a load-balanced ClusterIP and should not be used directly by clients
+  # in most circumstances.
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+  annotations:
+    # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "_status/vars"
+    prometheus.io/port: "8001"
+    uw.health.aggregator.enable: "false"
+spec:
+  ports:
+  - port: 26257
+    targetPort: 26257
+    name: sql
+  - port: 26357
+    targetPort: 26357
+    name: rpc
+  - port: 8001
+    targetPort: 8001
+    name: http
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other CockroachDB pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector:
+    app: cockroachdb

--- a/cockroachdb/base/statefulset.yaml
+++ b/cockroachdb/base/statefulset.yaml
@@ -1,0 +1,231 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+  annotations:
+    "app.uw.systems/description": "Used to store data projections of events in multiple services."
+    "app.uw.systems/tier": "tier_1"
+    "app.uw.systems/repos.cockroachdb-manifests": "https://github.com/utilitywarehouse/cockroachdb-manifests"
+    "app.uw.systems/tags.oss": "true"
+spec:
+  serviceName: cockroachdb
+  replicas: 3
+  selector:
+    matchLabels:
+      app: cockroachdb
+  template:
+    metadata:
+      labels:
+        app: cockroachdb
+        policy.semaphore.uw.io/name: cockroachdb
+    spec:
+      serviceAccountName: cockroachdb
+      shareProcessNamespace: true
+      # No pre-stop hook is required, a SIGTERM plus some time is all that's
+      # needed for graceful shutdown of a node.
+      terminationGracePeriodSeconds: 60
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - cockroachdb
+                topologyKey: kubernetes.io/hostname
+      initContainers:
+        - name: init-certs
+          image: cockroach-cfssl-certs
+          imagePullPolicy: Always
+          command:
+            - "sh"
+            - "-c"
+            - >
+              cockroach-certs
+              --host=localhost
+              --host=127.0.0.1
+              --host=$(hostname -f)
+              --host=$(hostname -f|cut -f 1-2 -d '.')
+              --host=$(COCKROACH_HOST)
+              --host=$(COCKROACH_HOST).$(hostname -f|cut -f 3- -d '.')
+          env:
+            - name: CERTIFICATE_TYPE
+              value: "node"
+            - name: CERTS_DIR
+              value: "/cockroach-certs"
+            - name: CA_PROFILE
+              valueFrom:
+                configMapKeyRef:
+                  name: ca.config
+                  key: ca.node.profile
+            - name: CA_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                  name: ca.config
+                  key: ca.endpoint
+            - name: CA_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ca.auth
+                  key: key
+            - name: COCKROACH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: cockroach
+                  key: cockroach.host
+          volumeMounts:
+            - name: certs
+              mountPath: /cockroach-certs
+      containers:
+        - name: cockroachdb
+          image: cockroachdb
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/bin/bash"
+            - "-ecx"
+            # The use of qualified `hostname -f` is crucial:
+            # Other nodes aren't able to look up the unqualified hostname.
+            - >
+              exec /cockroach/cockroach start
+              --logtostderr=WARNING
+              --certs-dir /cockroach/cockroach-certs
+              --listen-addr=:26357
+              --sql-addr=:26257
+              --advertise-addr $(hostname -f)
+              --http-addr 0.0.0.0
+              --join $(COCKROACH_JOIN_STRING)
+              --cache $(CACHE)
+              --max-sql-memory $(MAX_SQL_MEMORY)
+          env:
+            - name: COCKROACH_CHANNEL
+              value: kubernetes-secure
+            - name: COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING
+              value: "true"
+            - name: CACHE
+              value: 256MB
+            - name: MAX_SQL_MEMORY
+              value: 256MB
+            - name: COCKROACH_JOIN_STRING
+              value: cockroachdb-0.cockroachdb:26257,cockroachdb-0.cockroachdb:26357,cockroachdb-1.cockroachdb:26257,cockroachdb-1.cockroachdb:26357,cockroachdb-2.cockroachdb:26257,cockroachdb-2.cockroachdb:26357
+          ports:
+            - containerPort: 26257
+              name: sql
+            - containerPort: 26357
+              name: rpc
+            - containerPort: 8080
+              name: http
+          livenessProbe:
+            httpGet:
+              path: "/health"
+              port: http
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: "/health?ready=1"
+              port: http
+              scheme: HTTPS
+            initialDelaySeconds: 60
+            periodSeconds: 5
+            failureThreshold: 2
+          volumeMounts:
+            - name: datadir
+              mountPath: /cockroach/cockroach-data
+            - name: certs
+              mountPath: /cockroach/cockroach-certs
+          resources:
+            requests:
+              cpu: "0m"
+              memory: "768Mi"
+            limits:
+              cpu: "4000m"
+              memory: "1Gi"
+        - name: certs-refresh
+          image: cockroach-cfssl-certs
+          imagePullPolicy: Always
+          command:
+            - "sh"
+            - "-c"
+            - >
+              cockroach-certs
+              --host=localhost
+              --host=127.0.0.1
+              --host=$(hostname -f)
+              --host=$(hostname -f|cut -f 1-2 -d '.')
+              --host=$(COCKROACH_HOST)
+              --host=$(COCKROACH_HOST).$(hostname -f|cut -f 3- -d '.')
+              refresh-and-forward
+          env:
+            - name: HTTP_PORT
+              value: "8001"
+            - name: FORWARD_HOST
+              value: "localhost:8080"
+            - name: FORWARD_TIMEOUT
+              value: "4s"
+            - name: EXTRA_TIME
+              value: "60m"
+            - name: CERTIFICATE_TYPE
+              value: "node"
+            - name: CERTS_DIR
+              value: "/cockroach-certs"
+            - name: CA_PROFILE
+              valueFrom:
+                configMapKeyRef:
+                  name: ca.config
+                  key: ca.node.profile
+            - name: CA_ADDRESS
+              valueFrom:
+                configMapKeyRef:
+                  name: ca.config
+                  key: ca.endpoint
+            - name: CA_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ca.auth
+                  key: key
+            - name: COCKROACH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: cockroach
+                  key: cockroach.host
+          volumeMounts:
+            - name: certs
+              mountPath: /cockroach-certs
+          securityContext:
+            capabilities:
+              add:
+                - SYS_PTRACE
+          ports:
+            - containerPort: 8001
+              name: http
+          livenessProbe:
+            httpGet:
+              path: "/health"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 40
+            periodSeconds: 30
+      volumes:
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: certs
+          emptyDir: {}
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 10Gi

--- a/cockroachdb/docs/backup.md
+++ b/cockroachdb/docs/backup.md
@@ -1,0 +1,14 @@
+# Backups
+
+This runbook describes the backup procedure and how to restore from a backup.
+
+## How to backup
+
+Using the manifests in this repo you have the option of setting a backup URL using the [configuration files](../examples/config/backup-config) and the [backup script](../base/scripts.yaml). This will automatically setup the backup schedule for you and if you have setup your s3 bucket and [vault injector](https://github.com/utilitywarehouse/documentation/blob/master/infra/vault/vault-aws.md) already the backups will all happen automatically on your schedule.
+
+When updating backup configs (e.g. schedule or url), existing crdb schedule might need to be dropped first. See the docs on how to [manage](https://www.cockroachlabs.com/docs/stable/manage-a-backup-schedule) or [drop](https://www.cockroachlabs.com/docs/v23.1/drop-schedules) these.
+In order for the new backup schedule to get created in the db the backup job needs to run again. Deleting the (existing, but previously) completed job and rerunning kube-applier will trigger it.
+
+## Restoring a backup
+
+The cockroach team have a complete example of restoring from a backup [here](https://www.cockroachlabs.com/docs/stable/restore.html)

--- a/cockroachdb/docs/pvc-resize.md
+++ b/cockroachdb/docs/pvc-resize.md
@@ -1,0 +1,238 @@
+# PVC resize
+
+This runbook looks to document how to deal with increasing the size of PVCs associated with CockroachDB deployments in
+kubernetes. For the purposes of this guide we will be discussing and providing examples in relation to this specific
+kustomize base, but the equivalent process can be applied for any statefulset.
+
+<!-- ToC start -->
+## Table of Contents
+
+   1. [Prepare changes](#prepare-changes)
+      1. [Determine where PVC size is defined](#determine-where-pvc-size-is-defined)
+      1. [Raise a PR increasing the PVC size](#raise-a-pr-increasing-the-pvc-size)
+         1. [With an existing overlay](#with-an-existing-overlay)
+         1. [Without an existing overlay](#without-an-existing-overlay)
+      1. [Disable kube-applier](#disable-kube-applier)
+   1. [Apply changes](#apply-changes)
+      1. [Edit PVCs](#edit-pvcs)
+      1. [Delete statefulset](#delete-statefulset)
+      1. [Merge your PR](#merge-your-pr)
+      1. [Apply manifests](#apply-manifests)
+<!-- ToC end -->
+
+## Prepare changes
+
+### Determine where PVC size is defined
+
+This first step is to figure our what is dictating the size of the existing PVCs. This kustomize base currently
+[defaults to 10GB](https://github.com/utilitywarehouse/cockroachdb-manifests/blob/795a82920d5977d7c07ace1ba73969f3e39d4411/base/statefulset.yaml#L196),
+for the PVC size. You can view the current size of the PVCs by executing the following:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> get pvc | grep '^datadir-cockroachdb'
+datadir-cockroachdb-0                     Bound    pvc-ce911399-2c65-4e87-9eb8-54e430552d1e   100Gi      RWO            netapp-ontap-san-ext4   348d
+datadir-cockroachdb-1                     Bound    pvc-00bc70ad-aba2-4501-be6b-036e56b1a574   100Gi      RWO            netapp-ontap-san-ext4   348d
+datadir-cockroachdb-2                     Bound    pvc-b0a99819-0fd3-45ca-b4d2-60c621196ece   100Gi      RWO            netapp-ontap-san-ext4   348d
+```
+
+If the size is greater than 10GB it is almost certainly the case that an overlay is in use.
+
+### Raise a PR increasing the PVC size
+
+A PR should be raised to the kubernetes-manifests repository. The PR is expected to be modifying the requested
+storage size in the `volumeClaimTemplates` section of the `cockroachdb` statefulset.
+
+#### With an existing overlay
+
+If you already have an overlay that patches the PVC size, simply adjust the value:
+
+```diff
+--- a/cluster/namespace/cockroachdb.yaml
++++ b/cluster/namespace/cockroachdb.yaml
+@@ -11,4 +11,4 @@ spec:
+           - "ReadWriteOnce"
+         resources:
+           requests:
+-            storage: 100Gi
++            storage: 120Gi
+```
+
+#### Without an existing overlay
+
+In the `kustomize.yaml` that imports this base, apply the following type of change, setting the
+`volumeClaimTemplates[0].spec.resources.requests.storage` value as desired:
+
+```diff
+--- /dev/null
++++ b/cluster/namespace/cockroachdb.yaml
+@@ -0,0 +1,14 @@
++apiVersion: apps/v1
++kind: StatefulSet
++metadata:
++  name: cockroachdb
++spec:
++  volumeClaimTemplates:
++    - metadata:
++        name: datadir
++      spec:
++        accessModes:
++          - "ReadWriteOnce"
++        resources:
++          requests:
++            storage: 100Gi
+--- a/cluster/namespace/kustomization.yaml
++++ b/cluster/namespace/kustomization.yaml
+@@ -200,3 +200,6 @@ resources:
+   - 01-auth.yaml
+   - 02-network-policies.yaml
+   - github.com/utilitywarehouse/cockroachdb-manifests//base?ref=v21.2.8-0
++
++patchesStrategicMerge:
++  - cockroachdb.yaml
+```
+
+### Disable kube-applier
+
+If your namespace has kube-applier in use, you may wish to disable it temporarily whilst you make changes.
+Alternatively, you can put it into dry-run mode.
+
+## Apply changes
+
+The `volumeClaimTemplates` section of a statefulset is immutable. Due to that, simply merging the changes prepared above
+will result in an error on apply. To work around this we must edit the underlying PVCs by hand, and then do some
+trickery to get the statefulset change applied.
+
+### Edit PVCs
+
+First, list out the PVCs:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> get pvc | grep '^datadir-cockroachdb'
+datadir-cockroachdb-0                     Bound    pvc-ce911399-2c65-4e87-9eb8-54e430552d1e   100Gi      RWO            netapp-ontap-san-ext4   348d
+datadir-cockroachdb-1                     Bound    pvc-00bc70ad-aba2-4501-be6b-036e56b1a574   100Gi      RWO            netapp-ontap-san-ext4   348d
+datadir-cockroachdb-2                     Bound    pvc-b0a99819-0fd3-45ca-b4d2-60c621196ece   100Gi      RWO            netapp-ontap-san-ext4   348d
+```
+
+Starting with `datadir-cockroachdb-0`, edit the PVC:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> edit pvc datadir-cockroachdb-0
+```
+
+(this will open the yaml representation of the PVC in your `$EDITOR`)
+
+Locate the following section:
+
+```yaml
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: netapp-ontap-san-ext4
+  volumeMode: Filesystem
+  volumeName: pvc-ce911399-2c65-4e87-9eb8-54e430552d1e
+```
+
+and modify the `storage` value to match the change in your PR:
+
+```diff
+--- a/...
++++ b/...
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+-     storage: 100Gi
++     storage: 120Gi
+  storageClassName: netapp-ontap-san-ext4
+  volumeMode: Filesystem
+  volumeName: pvc-ce911399-2c65-4e87-9eb8-54e430552d1e
+```
+
+Finally, exit your `$EDITOR`.
+
+To view the progress of the resize, you can describe the PVC:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> describe pvc datadir-cockroachdb-0 
+Name:          datadir-cockroachdb-0
+Namespace:     <namespace>
+StorageClass:  netapp-ontap-san-ext4
+Status:        Bound
+Volume:        pvc-ce911399-2c65-4e87-9eb8-54e430552d1e
+Labels:        app=cockroachdb
+Annotations:   pv.kubernetes.io/bind-completed: yes
+               pv.kubernetes.io/bound-by-controller: yes
+               volume.beta.kubernetes.io/storage-provisioner: csi.trident.netapp.io
+Finalizers:    [kubernetes.io/pvc-protection]
+Capacity:      100Gi
+Access Modes:  RWO
+VolumeMode:    Filesystem
+Used By:       cockroachdb-0
+Conditions:
+  Type                      Status  LastProbeTime                     LastTransitionTime                Reason  Message
+  ----                      ------  -----------------                 ------------------                ------  -------
+  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Wed, 13 Apr 2022 16:58:03 +0100           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
+Events:
+  Type     Reason                    Age   From                                    Message
+  ----     ------                    ----  ----                                    -------
+  Normal   Resizing                  21s   external-resizer csi.trident.netapp.io  External resizer is resizing volume pvc-ce911399-2c65-4e87-9eb8-54e430552d1e
+  Warning  ExternalExpanding         21s   volume_expand                           Ignoring the PVC: didn't find a plugin capable of expanding the volume; waiting for an external controller to process this PVC.
+  Normal   FileSystemResizeRequired  21s   external-resizer csi.trident.netapp.io  Require file system resize of volume on node
+```
+
+Note that the information made available may vary depending on the environment.
+
+After a short while you should hopefully find that the PVC is showing with an increased size:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> get pvc | grep '^datadir-cockroachdb'
+datadir-cockroachdb-0                     Bound    pvc-ce911399-2c65-4e87-9eb8-54e430552d1e   120Gi      RWO            netapp-ontap-san-ext4   348d
+datadir-cockroachdb-1                     Bound    pvc-00bc70ad-aba2-4501-be6b-036e56b1a574   100Gi      RWO            netapp-ontap-san-ext4   348d
+datadir-cockroachdb-2                     Bound    pvc-b0a99819-0fd3-45ca-b4d2-60c621196ece   100Gi      RWO            netapp-ontap-san-ext4   348d
+```
+
+Repeat this step for the remaining PVCs, until all are showing with the expected size:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> get pvc | grep '^datadir-cockroachdb'
+datadir-cockroachdb-0                     Bound    pvc-ce911399-2c65-4e87-9eb8-54e430552d1e   120Gi      RWO            netapp-ontap-san-ext4   348d
+datadir-cockroachdb-1                     Bound    pvc-00bc70ad-aba2-4501-be6b-036e56b1a574   120Gi      RWO            netapp-ontap-san-ext4   348d
+datadir-cockroachdb-2                     Bound    pvc-b0a99819-0fd3-45ca-b4d2-60c621196ece   120Gi      RWO            netapp-ontap-san-ext4   348d
+```
+
+### Delete statefulset
+
+Deleting and re-applying the statefulset is currently the simplest workaround to deal with the problems associated with
+`volumeClaimTemplates` being immutable. When deleting the statefulset, it is important to tell kubernetes to orphan
+the pods, etc - failing to do some will mean the kubernetes scheduler will scale down the entire cluster.
+
+Delete the statefulset using the following:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> delete sts --cascade=orphan cockroachdb                 
+statefulset.apps "cockroachdb" deleted
+```
+
+### Merge your PR
+
+Merge the PR containing the change that updates the `volumeClaimTemplates` value against the `cockroachdb` statefulset.
+
+### Apply manifests
+
+If you have disabled kube-applier, you can now re-enable it. In doing so, it may apply automatically - or failing that,
+the `Force apply run` button can be clicked in the relevant UI to force it to apply.
+
+If kube-applier is not in use, apply the changes as you normally would.
+
+Pod restarts might be required for the PVC resizes to finalise. After applying, the `cockroachdb` pods may automatically
+restart (this is currently the observed behaviour in merit). If for some reason they do not restart, you can force the
+statefulset to roll by executing the following:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> rollout restart sts cockroachdb                 
+statefulset.apps/cockroachdb restarted
+```

--- a/cockroachdb/docs/scaling.md
+++ b/cockroachdb/docs/scaling.md
@@ -1,0 +1,477 @@
+# Adding or removing CockroachDB nodes
+
+This runbook looks to document how to orchestrate adding, removing, re-adding, and replacing CockroachDB nodes. This is
+specifically written with this kustomize base in mind, however many parts are agnostic to how CockroachDB is deployed.
+
+<!-- ToC start -->
+## Table of Contents
+
+   1. [Before applying changes](#before-applying-changes)
+      1. [Check cluster health](#check-cluster-health)
+         1. [Verify pods are running and showing healthy](#verify-pods-are-running-and-showing-healthy)
+         1. [Inspect DB Console](#inspect-db-console)
+      1. [Review zone configurations](#review-zone-configurations)
+   1. [Apply changes](#apply-changes)
+      1. [Option 1: adding nodes](#option-1-adding-nodes)
+         1. [Increase replica count](#increase-replica-count)
+         1. [Review join flag (optional)](#review-join-flag-optional)
+         1. [Increase replication factor (optional)](#increase-replication-factor-optional)
+      1. [Option 2: removing nodes](#option-2-removing-nodes)
+         1. [Decommission](#decommission)
+         1. [Decrease replica count](#decrease-replica-count)
+         1. [Remove orphaned PVCs](#remove-orphaned-pvcs)
+         1. [Decrease replication factor (optional)](#decrease-replication-factor-optional)
+      1. [Option 3: re-adding nodes](#option-3-re-adding-nodes)
+         1. [Non-decommissioned nodes](#non-decommissioned-nodes)
+         1. [Decommissioned nodes](#decommissioned-nodes)
+      1. [Option 4: replacing nodes](#option-4-replacing-nodes)
+         1. [Scale up (if necessary)](#scale-up-if-necessary)
+         1. [Stop the problematic node](#stop-the-problematic-node)
+         1. [Decommission the problematic node](#decommission-the-problematic-node)
+         1. [Remove the PVC](#remove-the-pvc)
+         1. [Re-apply manifests](#re-apply-manifests)
+   1. [After applying changes](#after-applying-changes)
+      1. [Re-check cluster health](#re-check-cluster-health)
+<!-- ToC end -->
+
+## Before applying changes
+
+If the number of nodes is being changed under normal circumstances (i.e. not in reaction to issues resulting from a
+prior change to the replica count), the cluster should be checked first to ensure it is in a healthy state.
+
+### Check cluster health
+
+#### Verify pods are running and showing healthy
+
+Make sure from the kubernetes side of affairs, all the pods are healthy and all underlying containers are running:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> get pods | rg 'cockroachdb-[0-9]'
+cockroachdb-0                                                     3/3     Running                      0                  16m
+cockroachdb-1                                                     3/3     Running                      0                  25h
+cockroachdb-2                                                     3/3     Running                      2 (14h ago)        6d20h
+```
+
+If any pods are crash looping, or containers are missing from any pods (e.g. if one were to show `2/3`), this would need
+to be investigated and resolved before any nodes are introduced or removed from the cluster.
+
+#### Inspect DB Console
+
+The DB Console gives a decent overview of the health of nodes in a cluster, amongst other things. _TODO: link to
+documentation that explains how to access the DB Console_.
+
+Once you have the console open, check the following:
+
+- Replication Status: there should be no under-replicated ranges indicated
+- Node Status: all nodes should be displayed as live
+- Nodes List: all nodes should be indicating the same version
+
+### Review zone configurations
+
+If you're adding or removing nodes, you may need to tweak the replication factor in relation to the various zone. This
+is discussed later on, but for now, it's worth grabbing a copy of the zone configurations.
+
+To view the configuration, execute the following:
+
+```sql
+SHOW ZONE CONFIGURATIONS;
+```
+
+To execute this via the `cockroachdb-client` deployment, the following one-liner can be used:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> exec deployments/cockroachdb-client -c cockroachdb-client -- cockroach sql --execute "SHOW ZONE CONFIGURATIONS;"
+target  raw_config_sql
+RANGE default   "ALTER RANGE default CONFIGURE ZONE USING
+        range_min_bytes = 16777216,
+        range_max_bytes = 67108864,
+        gc.ttlseconds = 90000,
+        num_replicas = 3,
+        constraints = '[]',
+        lease_preferences = '[]'"
+DATABASE system "ALTER DATABASE system CONFIGURE ZONE USING
+        range_min_bytes = 16777216,
+        range_max_bytes = 67108864,
+        gc.ttlseconds = 90000,
+        num_replicas = 5,
+        constraints = '[]',
+        lease_preferences = '[]'"
+TABLE system.public.jobs        "ALTER TABLE system.public.jobs CONFIGURE ZONE USING
+        range_min_bytes = 16777216,
+        range_max_bytes = 67108864,
+        gc.ttlseconds = 600,
+        num_replicas = 5,
+        constraints = '[]',
+        lease_preferences = '[]'"
+RANGE meta      "ALTER RANGE meta CONFIGURE ZONE USING
+        range_min_bytes = 16777216,
+        range_max_bytes = 67108864,
+        gc.ttlseconds = 3600,
+        num_replicas = 5,
+        constraints = '[]',
+        lease_preferences = '[]'"
+RANGE system    "ALTER RANGE system CONFIGURE ZONE USING
+        range_min_bytes = 16777216,
+        range_max_bytes = 67108864,
+        gc.ttlseconds = 90000,
+        num_replicas = 5,
+        constraints = '[]',
+        lease_preferences = '[]'"
+RANGE liveness  "ALTER RANGE liveness CONFIGURE ZONE USING
+        range_min_bytes = 16777216,
+        range_max_bytes = 67108864,
+        gc.ttlseconds = 600,
+        num_replicas = 5,
+        constraints = '[]',
+        lease_preferences = '[]'"
+TABLE system.public.replication_constraint_stats        "ALTER TABLE system.public.replication_constraint_stats CONFIGURE ZONE USING
+        gc.ttlseconds = 600"
+TABLE system.public.replication_stats   "ALTER TABLE system.public.replication_stats CONFIGURE ZONE USING
+        gc.ttlseconds = 600"
+```
+
+The `num_replicas` setting indicates the replication factor for a given zone.
+
+## Apply changes
+
+The instructions depend on the nature of the change. So,
+
+- for adding nodes, jump to [`Option 1: adding nodes`](#option-1-adding-nodes)
+- for removing nodes, jump to [`Option 2: removing nodes`](#option-2-removing-nodes)
+- for re-adding nodes, jump to [`Option 3: re-adding nodes`](#option-3-re-adding-nodes)
+- for replacing nodes, jump to [`Option 4: replacing nodes`](#option-4-replacing-nodes)
+
+### Option 1: adding nodes
+
+#### Increase replica count
+
+This kustomize base defaults to 3 replicas. If you wish, you can increase the replica count. To achieve this, simply
+set the replicas count to the target value via the kustomize
+[`replicas` directive](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/replicas.md)
+
+```diff
+--- a/cluster/namespace/kustomization.yaml
++++ b/cluster/namespace/kustomization.yaml
+@@ -201,5 +201,9 @@ resources:
+   - 01-auth.yaml
+   - 02-network-policies.yaml
+   - github.com/utilitywarehouse/cockroachdb-manifests//base?ref=v21.2.8-0
+ 
++replicas:
++  - name: cockroachdb
++    count: 5
++
+ patchesStrategicMerge:
+   - cockroach.yaml
+```
+
+Apply via whatever normal route would be used. The kubernetes scheduler will then look to provision the additional pvcs,
+pods, etc, to satisfy the target count.
+
+#### Review join flag (optional)
+
+The [`--join`](https://github.com/utilitywarehouse/cockroachdb-manifests/blob/795a82920d5977d7c07ace1ba73969f3e39d4411/base/statefulset.yaml#L83)
+flag currently hardcodes the default initial 3 nodes of the cluster. This may change at some stage to make it more
+configurable, but please note that it is _not_ necessary to set all nodes in the cluster into the `--join` flag value.
+In fact, the CockroachDB team
+[actively recommend against including nodes beyond the first 3 to 5](https://www.cockroachlabs.com/docs/stable/cockroach-start.html):
+
+> --join, -j 
+> 
+> The host addresses that connect nodes to the cluster and distribute the rest of the node addresses. These can be IP addresses or DNS aliases of nodes.
+>
+> When starting a cluster in a single region, specify the addresses of 3-5 initial nodes. When starting a cluster in multiple regions, specify more than 1 address per region, and select nodes that are spread across failure domains. Then run the cockroach init command against any of these nodes to complete cluster startup. See the example below for more details.
+>
+> Use the same --join list for all nodes to ensure that the cluster can stabilize. Do not list every node in the cluster, because this increases the time for a new cluster to stabilize. Note that these are best practices; it is not required to restart an existing node to update its --join flag.
+> 
+> cockroach start must be run with the --join flag. To start a single-node cluster, use cockroach start-single-node instead.
+
+So, if you're for example scaling from 3 to 5, the `--join` flag can be left alone.
+
+#### Increase replication factor (optional)
+
+Increasing the count of nodes in a CockroachDB cluster _does not automatically result in any change to the
+[replication factor](https://www.cockroachlabs.com/docs/stable/architecture/replication-layer.html)_. The replication
+factor dictates the requested storage count of ranges across the nodes. If the requested count exceeds the number of
+nodes, generally speaking the number of nodes becomes the target replica count. In other words
+`target_replica_count = min(num_nodes, zone_num_replicas)`.
+
+The default zone configuration for system related data (i.e. data used by CockroachDB internals) sets `num_replicas` to
+5, whilst the default for user related data sets it to 3. That ultimately means that if you scale to 5 nodes, the
+clusters ability to survive a loss of 2 nodes may not be greatly improved, as ranges relating to user defined data may
+become unavailable. Whether this is an issue depends on the reasoning behind modifying the number of nodes:
+
+- if the increase was looking to try to improve performance in certain areas, or scale as data grows, you may feel
+  satisfied to leave the replication factor alone
+- if the increase was looking to try to improve availability, then you may wish to increase the replication factor
+
+If your circumstances do meet the needs to adjust replica count, you should decide the value to set based on the number
+of node failures you wish to be able to survive. This is ideally based on the following formula, though CockroachDB will
+likely accept any value and act appropriately.
+
+```
+number of node failures to tolerate = (replication factor - 1) / 2
+```
+
+So for example:
+- with a replication factor of 3, 1 node outage can be survived
+- with a replication factor of 5, 2 node outages can be survived
+- with a replication factor of 7, 3 node outages can be survived
+- .. and so on.
+
+Since CockroachDB will always respect the number of nodes in the cluster, if you wish to always have a replication
+factor that always matches the number of nodes, you can set the value to some arbitrary high value (e.g. 1000).
+
+Once you have decided on the target count, at minimum you'll want to adjust the `default` zone:
+
+```sql
+ALTER RANGE default CONFIGURE ZONE USING num_replicas = <target>;
+```
+
+Other zones may require adjustments depending on their current values and your desired target. Note that this setting
+will be lost if the cluster is ever re-built, so you may wish to document or create an init type job that forces the
+setting.
+
+### Option 2: removing nodes
+
+If there are surplus nodes in a CockroachDB cluster (either by original intent or by accident), or you have nodes in an
+irreparable state, those nodes can be
+[decommissioned](https://www.cockroachlabs.com/docs/stable/node-shutdown.html?filters=decommission).
+
+Please be aware that if you reduce the kubernetes side replica count without explicitly decommissioning the nodes,
+you run a real risk of ranges becoming unavailable and a resulting cluster outage. Should such circumstances occur, the
+best option is to [re-add those nodes](#option-3-re-adding-nodes), wait for the cluster to become healthy again, and
+then apply the following steps as normal.
+
+#### Decommission
+
+First, locate the IDs of the nodes you wish to decommission. When scaling a statefulset down, kubernetes will always
+remove pods from the tail end of the set to achieve the target replica count. So for example, a 5 node CockroachDB
+cluster may have the following pods:
+
+- `cockroachdb-0`
+- `cockroachdb-1`
+- `cockroachdb-2`
+- `cockroachdb-3`
+- `cockroachdb-4`
+
+And after scaling to 3, we'd expect there to be the following pods:
+
+- `cockroachdb-0`
+- `cockroachdb-1`
+- `cockroachdb-2`
+
+So `cockroachdb-3` and `cockroachdb-4` will have been removed.
+
+Given the parameters you're dealing with, first determine which pods are expected to be removed when the replica count
+is dropped. Then determine which CockroachDB node ID is assigned to nodes running on those pods - this can be achieved
+by either inspecting the DB console, or by running `cockroach node status` in the `cockroachdb-client` deployment:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> exec deployments/cockroachdb-client -c cockroachdb-client -- cockroach node status
+id      address sql_address     build   started_at      updated_at      locality        is_available    is_live
+1       cockroachdb-0.cockroachdb.namespace.svc.cluster.local:26257       cockroachdb-0.cockroachdb.namespace.svc.cluster.local:26257       v21.1.12        2022-03-28 13:07:45.605608      2022-04-07 13:22:38.441553                true    true
+2       cockroachdb-2.cockroachdb.namespace.svc.cluster.local:26257       cockroachdb-2.cockroachdb.namespace.svc.cluster.local:26257       v21.1.12        2022-03-28 10:10:42.439315      2022-04-07 13:22:36.03664         true    true
+3       cockroachdb-1.cockroachdb.namespace.svc.cluster.local:26257       cockroachdb-1.cockroachdb.namespace.svc.cluster.local:26257       v21.1.12        2022-03-28 14:31:19.07911       2022-04-07 13:22:38.883085                true    true
+4       cockroachdb-4.cockroachdb.namespace.svc.cluster.local:26257       cockroachdb-4.cockroachdb.namespace.svc.cluster.local:26257       v21.1.12        2022-03-28 16:23:27.421104      2022-04-07 13:22:35.658349                true    true
+5       cockroachdb-3.cockroachdb.namespace.svc.cluster.local:26257       cockroachdb-3.cockroachdb.namespace.svc.cluster.local:26257       v21.1.12        2022-03-28 12:33:26.462544      2022-04-07 13:22:35.790106                true    true
+```
+
+Sticking with the example where we're scaling from 5 to 3, we'd want to determine the node IDs for `cockroachdb-3` and
+`cockroachdb-4`. Based on the above output, the node ID for `cockroachdb-3` is 5, and the node ID for `cockroachdb-4`
+is 4. For the avoidance of any doubt: the numeric value on the end of each pods name and related hostname have zero
+bearing on the ID used by CockroachDB. Always locate the node ID via the DB console or `cockroach node status`.
+
+Once you have determined the IDs of the nodes that require decommissioning, you can tell the cluster to decommission
+those nodes. Ideally this is done one at time. Each respective node can be decommissioned via
+`cockroach node decommission <node-id>`. This can be executed via the `cockroachdb-client` deployment:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> exec deployments/cockroachdb-client -c cockroachdb-client -- cockroach node decommission <node-id>
+```
+
+The output of the command should give an indication of progress. If at any point during or after you wish to check the
+status of the various nodes, you can run `cockroach node status --decommission`; the `membership` for the node being
+decommissioned should ultimately update to `decommissioned` once the process has completed. You can also observe changes
+from the DB console:
+
+- the replica count against the decommissioning node should fall at time goes on
+- the node should ultimately show as decommissioned once the process has completed
+
+Once the node is observed to be decommissioned, check the cluster is still showing healthy.
+
+If there are further nodes to decommission, simply repeat this step which each respective node ID.
+
+#### Decrease replica count
+
+Once the target nodes have been decommissioned, the kubernetes side replica count can be reduced to match the desired
+number. So if you are decreasing from 5 to 3, the nodes relating to `cockroachdb-3` and `cockroachdb-4` are expected to
+be decommissioned by this stage. The replica count can then be changed as follows:
+
+To achieve this, simply
+set the replicas count to the target value via the kustomize
+[`replicas` directive](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/replicas.md)
+
+```diff
+--- a/cluster/namespace/kustomization.yaml
++++ b/cluster/namespace/kustomization.yaml
+@@ -201,5 +201,9 @@ resources:
+   - 01-auth.yaml
+   - 02-network-policies.yaml
+   - github.com/utilitywarehouse/cockroachdb-manifests//base?ref=v21.2.8-0
+ 
+replicas:
+  - name: cockroachdb
+-   count: 5
++   count: 3
+
+ patchesStrategicMerge:
+   - cockroach.yaml
+```
+
+(or in this instance the replicas direct can be removed entirely, as the default is 3). The kubernetes side change
+should be applied as normal.
+
+#### Remove orphaned PVCs
+
+When scaling a statefulset down, kubernetes does not by default remove the PVCs associated with removed pods. This is
+a useful property in a number of settings. However, with CockroachDB, once a node is decommissioned, it is permanently
+in that state and cannot be recovered. With that in mind, it is diligent to remove any associated PVCs to avoid any
+future confusion should you wish to scale up again. To delete the PVCs, simply remove those associated with the now
+removed pods:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> delete pvc datadir-<pod-name>
+```
+
+With the prior example where `cockroachdb-3` and `cockroachdb-4` have been removed, this would end up looking like:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> delete pvc datadir-cockroachdb-3
+$ kubectl --context=<cluster> --namespace=<namespace> delete pvc datadir-cockroachdb-4
+```
+
+#### Decrease replication factor (optional)
+
+If the replication factor has been previously increased whilst adding nodes (see
+[Increase replication factor (optional)](#increase-replication-factor-optional)), you _may_ wish to now decrease it.
+CockroachDB is happy to operate with a higher requested replica count than can be achieved via the number of nodes in
+the cluster, so the replication factor only needs to be decreased if you want it to be a value that is lower than the
+node count.
+
+For example, if you are running a 7 node cluster with a replication factor of 7, and then reduce the node count to 5, if
+you're happy with 5 replicas being stored, then there is nothing to do - however, if you now wanted to operate with 3 
+replicas being stored, you'd need to adjust the replication factor.
+
+Refer to [Increase replication factor (optional)](#increase-replication-factor-optional) for instructions on changing
+value.
+
+### Option 3: re-adding nodes
+
+If nodes have been taken offline, it _may_ be possible to bring them back into action.
+
+#### Non-decommissioned nodes
+
+If you've accidentally scaled a cluster down without decommissioning nodes, you may be facing issues due to unavailable
+ranges. To re-add nodes in such circumstances, simply increase the replica count again:
+
+```diff
+--- a/cluster/namespace/kustomization.yaml
++++ b/cluster/namespace/kustomization.yaml
+@@ -201,5 +201,9 @@ resources:
+   - 01-auth.yaml
+   - 02-network-policies.yaml
+   - github.com/utilitywarehouse/cockroachdb-manifests//base?ref=v21.2.8-0
+ 
+replicas:
+  - name: cockroachdb
+-   count: 3
++   count: 5
+
+ patchesStrategicMerge:
+   - cockroach.yaml
+```
+
+Apply as normal, and hopefully the cluster will become healthy again. Assuming you still wish to scale down to the 
+a lower replica count, [follow the process documented above](#option-2-removing-nodes).
+
+#### Decommissioned nodes
+
+CockroachDB does support
+[recommissioning nodes](https://www.cockroachlabs.com/docs/v21.2/node-shutdown?filters=decommission#recommission-nodes),
+but only if the node is in _decommissioning_ state. Once a node is decommissioned, it is permanently in that state and
+cannot be recommissioned. With that in mind, if any PVCs are still around covering pods that would come into existence
+after increasing the kubernetes side replica count, these need to be removed.
+
+Once you have verified no PVCs will be claimed when scaling up, [add the desired nodes as normal](#option-1-adding-nodes).
+
+### Option 4: replacing nodes
+
+There are very occasional circumstances where a node may need to be replaced. Almost always this is because of a node
+getting into some corrupted state due to a bug.
+
+#### Scale up (if necessary)
+
+When replacing a problematic node, the node will first off need decommissioning. When taking the replication count into
+consideration, it is important to note that CockroachDB to does not treat a decommissioning node as contributing to
+target value. So if `num_replicas` is set to 5 for a given zone, with 5 nodes in the cluster, it is permitted to reduce
+down to 4 nodes; CockroachDB will simply look to have 4 replicas stored. The exception to this rule is when operating a
+3 node cluster - CockroachDB generally does not want to let you reduce to 2 nodes - as a CockroachDB employee puts it:
+
+> What you WILL have trouble with, is decommissioning from a 3 node cluster to a 2 node cluster. It's like when Ant-Man
+> enters the Quantum Realm - the rules start to change when things get small.
+
+With that in mind, if you're operating with a 3 node cluster, you at minimum need to add 1 additional node before
+proceeding. Nodes can be added via the [normal process](#option-1-adding-nodes). You _may_ be able to get away with
+leaving the node in decommissioning state, continuing the process, then attempt to decommission again once the
+replacement node is action; your mileage may vary, and this is generally not recommended. 
+
+#### Stop the problematic node
+
+The node that requires replacement may be crash looping or otherwise misbehaving depending on the nature of the problem.
+It is worth stopping it not only to avoid this causing any potential problems whilst decommissioning, but also to make
+it simpler to remove the underlying PVC.
+
+One of the easiest options to achieve this is to temporarily remove the underlying statefulset with the orphan flag set:
+this ensures that the pods remain active, but also means that any pods that are stopped do not come back up.
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> delete sts --cascade=orphan cockroachdb
+```
+
+Once this is done, delete the pod that requires replacement:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> delete pod <pod-name>
+```
+
+#### Decommission the problematic node
+
+The node should be decommissioned in a similar fashion to the process applied when
+[scaling a cluster down to fewer nodes](#decommission):
+
+- locate the CockroachDB node ID relating to the problematic node via `cockroach node status` or the DB console
+- run `cockroach node decommission <node-id>` via the `cockroachdb-client` deployment
+- wait for the decommissioning process to finish
+
+#### Remove the PVC
+
+Once the node has been confirmed to be decommissioned, you can delete the underlying PVC:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> delete pvc datadir-<pod-name>
+```
+
+#### Re-apply manifests
+
+After the PVC has been cleared, you can re-apply the manifests as normal (if kube-applier is in use, just hit "Force
+apply run" on relevant namespace). This will re-create the statefulset, at which point kubernetes will notice the
+missing pod and underlying PVC, and provision them.
+
+## After applying changes
+
+### Re-check cluster health
+
+Whether you're adding, removing, re-adding, or replacing nodes, you should always check on the state of the cluster
+after making modifications. The same steps [taken before applying changes](#check-cluster-health) can be applied after -
+in particular make sure there are no under-replicated ranges being reported.

--- a/cockroachdb/docs/upgrade.md
+++ b/cockroachdb/docs/upgrade.md
@@ -1,0 +1,385 @@
+# CockroachDB upgrade
+
+This runbook looks to document how to orchestrate CockroachDB version updates. Please keep in mind that, whilst many
+parts of this guide are universal in relation to CockroachDB, some steps are specific to deployments created via this
+kustomize base.
+
+<!-- ToC start -->
+## Table of contents
+
+   1. [Before upgrading](#before-upgrading)
+      1. [Figure out what type of upgrade is to be applied](#figure-out-what-type-of-upgrade-is-to-be-applied)
+      1. [Locate the appropriate tag](#locate-the-appropriate-tag)
+      1. [Check cluster status](#check-cluster-status)
+         1. [Verify pods are running and showing healthy](#verify-pods-are-running-and-showing-healthy)
+         1. [Inspect DB Console](#inspect-db-console)
+         1. [List nodes](#list-nodes)
+         1. [Check the internal cluster version](#check-the-internal-cluster-version)
+      1. [Notify teams](#notify-teams)
+      1. [Create a manual backup](#create-a-manual-backup)
+      1. [Clear init and backup jobs](#clear-init-and-backup-jobs)
+   1. [Upgrade](#upgrade)
+      1. [Option 1: patch version upgrade](#option-1-patch-version-upgrade)
+         1. [Update manifests and apply](#update-manifests-and-apply)
+      1. [Option 2: major version upgrade](#option-2-major-version-upgrade)
+         1. [Review upgrade guide](#review-upgrade-guide)
+         1. [Disable auto upgrade finalization](#disable-auto-upgrade-finalization)
+         1. [Update manifests and apply](#update-manifests-and-apply-1)
+   1. [Monitor](#monitor)
+   1. [Finish](#finish)
+      1. [Finalize (if required)](#finalize-if-required)
+         1. [Verify](#verify)
+      1. [Rollback (if required)](#rollback-if-required)
+         1. [Disaster recovery](#disaster-recovery)
+<!-- ToC end -->
+
+## Before upgrading
+
+### Figure out what type of upgrade is to be applied
+
+When looking to upgrade to a newer version of CockroachDB, it is important to understand the nature of the upgrade.
+CockroachDB does not use semantic versioning, rather, calendar-based versioning is used with the following format:
+
+```
+<2-digit-year>.<release-number>.<patch-release-number>
+```
+
+Breaking changes are typically made across `<2-digit-year>.<release-number>` increases.
+
+For want of better terms, in this guide we will refer to "major" and "patch" version updates. When reviewing the
+differences between the old and new versions of CockroachDB, if the `<2-digit-year>.<release-number>` section is
+changing, this implies a major version update. If just the `<patch-release-number>` element has changed, this implies a
+patch version update.
+
+To show that by example:
+
+- before = `v21.1.16`, after = `v21.2.0`: major
+- before = `v21.1.1`, after = `v21.1.16`: patch
+- before = `v21.2.7`, after = `v22.1.0`: major
+
+### Locate the appropriate tag
+
+Check https://github.com/utilitywarehouse/cockroachdb-manifests/tags
+
+If the target version is new, and a tag has not yet been created, please open a PR to adjust the image tag in master.
+After that has been merged, a new release can be created. Note that the tagging strategy in this repository is:
+
+```
+<cockroach-version>-<manifests-version-number>
+```
+
+That is to say, when CockroachDB `v22.1.0` is released, a tag will be created named `v22.1.0-1`. If we make further
+changes to the manifests, but no CockroachDB version change is made, we may create a new tag named `v22.1.0-2`.
+(Release count starts at 1, similarly to other UW repositories.)
+You should typically look to use the most recent tag pertaining to the CockroachDB version you are targeting. Due to the
+nature of these manifests, you should review any changes between the current and target tag. One convenient way to do 
+this is via
+
+```
+https://github.com/utilitywarehouse/cockroachdb-manifests/compare/<curent-tag>...<target-tag>
+```
+
+e.g. https://github.com/utilitywarehouse/cockroachdb-manifests/compare/v21.2.1-0...v21.2.7-1
+
+### Check cluster status
+
+Before moving forward with the upgrade, you should first verify the cluster is in a healthy state. This can be achieved
+through numerous options.
+
+#### Verify pods are running and showing healthy
+
+Make sure from the kubernetes side of affairs, all the pods are healthy and all underlying containers are running:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> get pods | rg 'cockroachdb-[0-9]'
+cockroachdb-0                                                     3/3     Running                      0                  16m
+cockroachdb-1                                                     3/3     Running                      0                  25h
+cockroachdb-2                                                     3/3     Running                      2 (14h ago)        6d20h
+```
+
+If any pods are crash looping, or containers are missing from any pods (e.g. if one were to show `2/3`), this would need
+to be investigated and resolved before any upgrades are applied.
+
+#### Inspect DB Console
+
+The DB Console gives a decent overview of the health of nodes in a cluster, amongst other things. _TODO: link to
+documentation that explains how to access the DB Console_.
+
+Once you have the console open, check the following:
+
+- Replication Status: there should be no under-replicated ranges indicated
+- Node Status: all nodes should be displayed as live
+- Nodes List: all nodes should be indicating the same version
+- Jobs (in the sidebar): having jobs active during an upgrade is technically fine (unless otherwise indicated by 
+CockroachDB documentation), however, it might be diligent to verify that there are no stuck jobs. If there are any long
+running jobs it may be worth allowing these to compete before proceeding.
+
+#### List nodes
+
+You can also look to inspect the status of nodes via `cockroach node status`. This can be issued via the
+`cockroachdb-client` deployment. In particular, you should look out of any nodes stuck in `decommissioning` status, as
+this may block the upgrade:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> exec deployments/cockroachdb-client -c cockroachdb-client -- cockroach node status --decommission
+id      address sql_address     build   started_at      updated_at      locality        is_available    is_live gossiped_replicas       is_decommissioning      membership      is_draining
+1       cockroachdb-0.cockroachdb.namespace.svc.cluster.local:26257       cockroachdb-0.cockroachdb.namespace.svc.cluster.local:26257       v21.2.7 2022-03-30 14:19:50.692222      2022-03-30 15:06:19.708401true    true    4373    false   active  false
+2       cockroachdb-2.cockroachdb.namespace.svc.cluster.local:26257       cockroachdb-2.cockroachdb.namespace.svc.cluster.local:26257       v21.2.7 2022-03-30 00:02:15.486786      2022-03-30 15:06:21.227482true    true    4373    false   active  false
+3       cockroachdb-1.cockroachdb.namespace.svc.cluster.local:26257       cockroachdb-1.cockroachdb.namespace.svc.cluster.local:26257       v21.2.7 2022-03-29 13:05:01.599074      2022-03-30 15:06:19.663817true    true    4373    false   active  false
+```
+
+#### Check the internal cluster version
+
+Optionally you may wish to check that the internal cluster version matches the binary version. If it does not, this is
+bad sign, and you should investigate before proceeding.
+
+The version displayed in the DB console, etc, is typically going to be the binary version. To check the cluster version,
+run the following:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> exec deployment/cockroachdb-client -c cockroachdb-client -- cockroach sql --execute 'SHOW CLUSTER SETTING version;'
+```
+
+As an example, for a cluster running the `v21.2.7`, the above should output `21.2`.
+
+### Notify teams
+
+Before triggering the upgrade, you may wish to notify developers that are familiar with the target cluster. There are
+a couple of reasons behind this:
+
+- the timing of the upgrade might be sensitive for some reason
+- if there are any issues relating to the upgrade, they'll have some context
+
+Assuming there are no problems flagged, continue on.
+
+### Create a manual backup (optional)
+
+When moving to a new major version, whilst no issues are expected from upgrading CockroachDB, it is diligent to create a
+backup before upgrading, _just in case_. If you're moving to a new patch version you may choose to omit this step,
+considering the even lesser likelihood of issues and the ease at which you can rollback.
+
+CockroachDB clusters deployed against this kustomize base are expected to use the native backup mechanism, which makes
+it trivial to make ad-hoc backups. Simply use the same bucket and path (if applicable) that is targeted by the scheduled
+backups:
+
+```sql
+BACKUP INTO 's3://<bucket>/<path>/ad-hoc-backup-YYYYMMDD-01/?AUTH=implicit' AS OF SYSTEM TIME '-10s';
+```
+
+You can find the path in the kubernetes-manifest by searching for `destination.url` in the relevant namespace.
+
+This can be issued via the `cockroachdb-client` deployment using the following one-liner:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> exec deployments/cockroachdb-client -c cockroachdb-client -- cockroach sql --execute "BACKUP TO 's3://<bucket>/<path>/ad-hoc-backup-YYYYMMDD-01/?AUTH=implicit' AS OF SYSTEM TIME '-10s';"
+```
+
+### Clear init and backup jobs
+
+Before applying an upgrade, any existing `cockroach-init` and `cockroach-backup-init` jobs should be removed. This is
+because the manifests for these jobs will start to reference the newer version, and since jobs are immutable, an error
+will appear when looking to apply:
+
+```
+The Job "cockroach-init" is invalid: spec.template: Invalid value: <snip>: field is immutable
+```
+
+To clear the jobs, simply run the following:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> delete job cockroach-init cockroach-backup-init
+```
+
+Note that the jobs will be recreated when the manifests are next applied - it is safe for both jobs to be re-run.
+
+## Upgrade
+
+The instructions are slightly different depending on the nature of the upgrade, so:
+
+- for patch version upgrades, jump to [`Option 1: patch version upgrade`](#option-1-patch-version-upgrade)
+- for major version upgrades, jump to [`Option 2: major version upgrade`](#option-2-major-version-upgrade)
+
+### Option 1: patch version upgrade
+
+Unless otherwise stated in any documentation from CockroachDB, no breaking changes or complex internal migrations are
+made in patch releases. With that being the case, you can freely move up (or indeed down) patch versions as desired. All
+that said, it would still be diligent to review the [release notes](https://www.cockroachlabs.com/docs/releases/index.html)
+and [technical advisories](https://www.cockroachlabs.com/docs/advisories/index.html) before proceeding.
+
+#### Update manifests and apply
+
+Adjust the kustomize base ref to match the new target version. For example:
+
+```diff
+--- a/cluster/namespace/kustomization.yaml
++++ b/cluster/namespace/kustomization.yaml
+@@ -57,7 +57,7 @@ resources:
+   - 00-namespace.yaml
+   - 01-auth.yaml
+   - 02-network-policies.yaml
+-  - github.com/utilitywarehouse/cockroachdb-manifests//base?ref=v21.2.6-0
++  - github.com/utilitywarehouse/cockroachdb-manifests//base?ref=v21.2.7-0
+ 
+ patchesStrategicMerge:
+   - cockroach.yaml
+```
+
+Then apply as normal (either by hand, or via kube-applier).
+
+### Option 2: major version upgrade
+
+It is important to note that you can only move 1 major version at a time. That is to say, you would be able to upgrade
+from `v21.1` to `v21.2`, but you wouldn't be able to upgrade directly from `v19.2` to `v21.2`. If there is more than
+one version between the current and target version, you need to upgrade one version at a time. For example, to move from
+`v19.2` to `v21.2`, you'd first upgrade to `v21.1`, and then upgrade to `v21.2`.
+
+#### Review upgrade guide
+
+CockroachDB produce upgrade guides for each major version change. The relevant version should be reviewed before 
+proceeding:
+
+- 23.1 to 23.2: https://www.cockroachlabs.com/docs/v23.2/upgrade-cockroach-version
+- 22.2 to 23.1: https://www.cockroachlabs.com/docs/v23.1/upgrade-cockroach-version.html
+- 22.1 to 22.2: https://www.cockroachlabs.com/docs/v22.2/upgrade-cockroach-version.html
+- 21.2 to 22.1: https://www.cockroachlabs.com/docs/v22.1/upgrade-cockroach-version.html
+- 21.1 to 21.2: https://www.cockroachlabs.com/docs/v21.2/upgrade-cockroach-version.html
+- 20.2 to 21.1: https://www.cockroachlabs.com/docs/v21.1/upgrade-cockroach-version.html
+- 20.1 to 20.2: https://www.cockroachlabs.com/docs/v20.2/upgrade-cockroach-version.html
+- 19.2 to 20.1: https://www.cockroachlabs.com/docs/v20.1/upgrade-cockroach-version
+- 19.1 to 19.2: https://www.cockroachlabs.com/docs/v19.2/upgrade-cockroach-version
+
+#### Disable auto upgrade finalization
+
+When CockroachDB finalizes an upgrade, it applies internal migrations, amongst other things, to unlock new features
+and bring the internal state in line with new expectations. Due to the nature of this, upgrade finalization is a
+"no turning back" type operation.
+
+CockroachDB defaults to automatically finalizing an upgrade once all nodes in a cluster are running the newer version.
+This is undoubtedly convenient, but it also carries risks. We've had more than one incident where a cluster has been
+finalized against a new version, but there have been issues appear relating to the upgrade after that point. With that
+in mind, you can proceed with the default auto upgrade finalization enabled, or, you may wish to disable it (which the
+CockroachDB team recommend).
+
+To disable auto upgrade finalization, you need to tell CockroachDB that you wish to have the option to downgrade back to
+the previous version (ignoring the patch element). This can be achieved by setting the
+`cluster.preserve_downgrade_option` cluster setting via the `cockroachdb-client` deployment.
+
+So for example, if you're upgrading from `v21.1.16` to `v21.2.7`, you'd execute the following:
+
+```sql
+SET CLUSTER SETTING cluster.preserve_downgrade_option = '21.1';
+```
+
+To execute this via the `cockroachdb-client` deployment, the following one-liner can be used:
+
+```
+$ kubectl --context=<cluster> --namespace=<namespace> exec deployments/cockroachdb-client -c cockroachdb-client -- cockroach sql --execute "SET CLUSTER SETTING cluster.preserve_downgrade_option = '21.1';"
+```
+
+At any point you wish to check what this value is set to, simply run:
+
+```sql
+SHOW CLUSTER SETTING cluster.preserve_downgrade_option;
+```
+
+#### Update manifests and apply
+
+Adjust the kustomize base ref to match the target version. As a reminder, the target version can only be one increment
+above the previous (excluding the patch element).
+
+```diff
+--- a/cluster/namespace/kustomization.yaml
++++ b/cluster/namespace/kustomization.yaml
+@@ -57,7 +57,7 @@ resources:
+   - 00-namespace.yaml
+   - 01-auth.yaml
+   - 02-network-policies.yaml
+-  - github.com/utilitywarehouse/cockroachdb-manifests//base?ref=v21.1.16-0
++  - github.com/utilitywarehouse/cockroachdb-manifests//base?ref=v21.2.7-0
+ 
+ patchesStrategicMerge:
+   - cockroach.yaml
+```
+
+Then apply as normal (either by hand, or via kube-applier).
+
+## Monitor
+
+Once the updated manifests have been applied, the following behaviour is expected to be observed:
+
+- all the pods relating to the `cockroachdb` stateful set will restart, moving to the new image tag
+- the `cockroachdb-client` deployment job will restart, moving to the new image tag
+- `cockroach-init` and `cockroach-backup-init` jobs will spawn - both are safe run at any point, so don't be alarmed
+
+After the above has completed, keep an eye out for alerts.
+
+## Finish
+
+To finish the upgrade, you may need to finalize. If the upgrade has not gone to plan, you can look to roll it back.
+
+### Finalize (if required)
+
+This step is only required for major version upgrades, where auto upgrade finalization was disabled.
+
+Once a suitable period of time has elapsed running against the new version of CockroachDB, you can look to finalize the
+upgrade. The amount of time you leave the cluster in a non upgrade finalized state will vary case by case, but at 
+minimum you should look to give it at least 1 day.
+
+Before finalizing, check that the cluster is healthy (see [`Check cluster status`](#check-cluster-status))
+
+Once you're happy that the cluster is stable, issue the following statement via the `cockroachdb-client` deployment:
+
+```sql
+RESET CLUSTER SETTING cluster.preserve_downgrade_option;
+```
+
+Unless otherwise indicated in release notes, it should _not_ be necessary to restart the nodes after executing the
+above.
+
+#### Verify
+
+There are circumstances under which CockroachDB may decide to not move forward with finalizing the upgrade. As an
+example, if there is a node stuck in "decommissioning" state, the upgrade may not complete. Whilst such circumstances
+are rare and unexpected, it would be diligent to check that the cluster has finalized after resetting
+`cluster.preserve_downgrade_option`.
+
+To do so, check the output of the `version` cluster setting via the `cockroachdb-client` deployment:
+
+```sql
+SHOW CLUSTER SETTING version;
+```
+
+Note that there might be a small delay after clearing the `cluster.preserve_downgrade_option` setting before this
+updates. It may also update multiple times whilst the internal state migrates.
+
+If there is any sign that the upgrade is not finalizing correctly, you should check the job listing to see if there
+are any jobs in progress;
+
+```sql
+SHOW JOBS;
+```
+
+If any jobs fail to complete, this signifies there is an issue. Unfortunately, the point of no return has likely been
+hit, in which case support may be required from colleagues or the CockroachDB devs.
+
+### Rollback (if required)
+
+If the upgrade has undesirable results, you can look to roll it back. Note that in the case of a major version change,
+this is only possible if the upgrade has not been finalized.
+
+To roll the upgrade back, simply repeat the same steps but target the previous version. If there are issues, it is
+quite possible that the cluster will not be in a healthy state; pay close attention to the DB Console, if accessible.
+You may wish to confer with colleagues in deciding the best course of action to take under these circumstances.
+
+#### Disaster recovery
+
+If the upgrade fails in a way where rolling back is no longer viable, and the cluster cannot be made stable, the last
+resort is to wipe the cluster and recover from backup (or an alternative source for the underlying data, if available).
+
+If you wish to recover from backup, once the new cluster has been brought up, execute the following:
+
+```sql
+RESTORE FROM 's3://<bucket>/<path>/ad-hoc-backup-YYYYMMDD-01/?AUTH=implicit';
+```
+
+This should restore all databases, tables, users, etc.

--- a/cockroachdb/examples/README.md
+++ b/cockroachdb/examples/README.md
@@ -1,0 +1,1 @@
+Please note that cfssl is deprecated and cert-manager is recommended.

--- a/cockroachdb/examples/cert-manager/certificates-patch.yaml
+++ b/cockroachdb/examples/cert-manager/certificates-patch.yaml
@@ -1,0 +1,89 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: node
+spec:
+  issuerRef:
+    name: ca-issuer
+    kind: Issuer
+  commonName: node
+  dnsNames:
+    - cockroachdb-0.cockroachdb
+    - cockroachdb-1.cockroachdb
+    - cockroachdb-2.cockroachdb
+    - cockroachdb-0.cockroachdb.<your namespace here>.svc.cluster.local
+    - cockroachdb-1.cockroachdb.<your namespace here>.svc.cluster.local
+    - cockroachdb-2.cockroachdb.<your namespace here>.svc.cluster.local
+---
+# https://www.cockroachlabs.com/docs/stable/authentication#using-cockroach-cert-or-openssl-commands
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cockroachdb
+spec:
+  template:
+    spec:
+      volumes:
+        - name: certs
+          secret:
+            $patch: delete
+          projected:
+            sources:
+              - secret:
+                  name: cockroachdb.node
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                    - key: tls.crt
+                      path: node.crt
+                    - key: tls.key
+                      path: node.key
+            defaultMode: 256
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cockroach-init
+spec:
+  template:
+    spec:
+      volumes:
+        - name: client-certs
+          secret:
+            $patch: delete
+          projected:
+            sources:
+              - secret:
+                  name: cockroachdb.client.root
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                    - key: tls.crt
+                      path: client.root.crt
+                    - key: tls.key
+                      path: client.root.key
+            defaultMode: 256
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cockroachdb-client
+spec:
+  template:
+    spec:
+      volumes:
+        - name: client-certs
+          secret:
+            $patch: delete
+          projected:
+            sources:
+              - secret:
+                  name: cockroachdb.client.root
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                    - key: tls.crt
+                      path: client.root.crt
+                    - key: tls.key
+                      path: client.root.key
+            defaultMode: 256

--- a/cockroachdb/examples/cert-manager/cockroach.yaml
+++ b/cockroachdb/examples/cert-manager/cockroach.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cockroachdb
+spec:
+  template:
+    metadata:
+      annotations:
+        uw.systems/kyverno-inject-sidecar-request: vault-sidecar-aws
+    spec:
+      containers:
+        - name: cockroachdb
+          resources:
+            requests:
+              cpu: 0
+              memory: "1Gi"
+            limits:
+              cpu: 4
+              memory: "2Gi"
+          env:
+            - name: CACHE
+              value: 256MB
+            - name: MAX_SQL_MEMORY
+              value: 256MB
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 50Gi

--- a/cockroachdb/examples/cert-manager/config/backup-config
+++ b/cockroachdb/examples/cert-manager/config/backup-config
@@ -1,0 +1,2 @@
+schedule=0 0,12 * * *
+destination.url=<your s3 bucket url here>

--- a/cockroachdb/examples/cert-manager/config/cockroach
+++ b/cockroachdb/examples/cert-manager/config/cockroach
@@ -1,0 +1,2 @@
+cockroach.host=cockroachdb-proxy
+cockroach.port=26257

--- a/cockroachdb/examples/cert-manager/kustomization.yaml
+++ b/cockroachdb/examples/cert-manager/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - sa.yaml
+  - github.com/utilitywarehouse/cockroachdb-manifests//base-cert-manager?ref=v23.2.2-1
+
+patches:
+  - path: certificates-patch.yaml
+  - path: cockroach.yaml
+
+configMapGenerator:
+  - name: cockroach
+    envs:
+      - config/cockroach
+  - name: cockroach.backup.config
+    envs:
+      - config/backup-config

--- a/cockroachdb/examples/cert-manager/sa.yaml
+++ b/cockroachdb/examples/cert-manager/sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cockroachdb
+  namespace: <your namespace here>
+  annotations:
+    vault.uw.systems/aws-role: <your aws role here>

--- a/cockroachdb/examples/cfssl/README.md
+++ b/cockroachdb/examples/cfssl/README.md
@@ -1,0 +1,98 @@
+# DEPRECATED
+We have replaced `cfssl` with `cert-manager` for CockroachDB certificates. Please refer to [cert-manager examples](https://github.com/utilitywarehouse/cockroachdb-manifests/examples/cert-manager) for up-to-date manifests.
+
+# cockroachdb-manifests
+
+This is a Kustomization base for deploying CockroachDB to a Kubernetes cluster. The base depends on Cloudflare's
+[cfssl](https://github.com/cloudflare/cfssl) as a Certificate Authority for signing certificates for
+securing communication between nodes and clients.
+
+## Deployment
+
+To deploy a cockroachdb cluster in your namespace you will need to complete the following steps:
+1. Configure and Deploy a Certificate Authority by following the [readme](./CFSSL_README.md). This will secure access for your cockroach cluster and clients.
+2. Setup a `kustomization.yaml` file that will use the bases defined here with your own configuration layered over the top. There is an [examples/single-cluster](./examples/single-cluster/) folder that can be used as a starting point. By filling in the missing pieces (e.g. certs, backup config, etc) you should get a running CA and CRDB cluster with periodic backups to S3 and AWS creds injected via [vault](https://github.com/utilitywarehouse/documentation/blob/master/infra/vault/vault-aws.md) (assumes an existing vault setup).
+
+### Single namespace - multiple CockroachDB clusters
+
+While the preference is to have a single CockroachDB cluster per namespace, in some cases this isn't ideal. 
+
+An example of this is in the Energy team where they have recently split into three squads but currently still share use of the `energy-platform` namespace. 
+
+In order to deploy multiple CockroachDB clusters within a single namespace whilst avoiding naming conflicts we can make use of the `namePrefix` and/or `nameSuffix` ability of Kustomize. 
+This will automagically update the names of resources within a Kustomization as well as the selectors and labels. 
+
+One part of this that Kustomize is not able to help with is with the CockroachDB specific commands that are used to create and join nodes to the cluster. 
+For this two environment variables have been added `COCKROACH_INIT_HOST` and `COCKROACH_JOIN_STRING`. 
+
+- `COCKROACH_INIT_HOST` is used by the `init-job.yaml` manifest to initialise the first node in the cluster
+- `COCKROACH_JOIN_STRING` is in the `statefulset.yaml` manifest to define which nodes will be joining the cluster. 
+
+There are sensible defaults for these environment variables to ensure that a single cluster within a namespace can be brought up without overriding any environment variables. 
+
+
+### Versioning
+
+This repo uses tags to manage versions, these tags have two components:
+
+  - The version of the `cockroachdb/cockroach` image the manifests are using
+  - An internal version to track changes to anything besides the version of
+    CockroachDB
+
+These tags are of the form `<cockroachdb-version>-<internal-version>`, for
+example: `v23.1.10-2` is the 2nd internal version of these manifests supporting
+`cockroachdb/cockroachv:23.1.10`
+
+### Configuration
+The Certificate Authority is configured by a config map. This specifies the cfssl certificate authority
+API endpoint and the profile used to sign client and peer certificates. These profiles must match the
+cfssl configuration.
+Example:
+```
+ca.node.profile=server
+ca.client.profile=client
+ca.endpoint=certificate-authority:8080
+```
+The auth key to sign the certificate is passed in as a secret.
+Cockroach DB requires some base configuration that can be overridden. (An example is below)
+- Note: `cockroach.host` and `cockroach.port` are required by the backup job.
+```
+cockroach.host=cockroachdb-proxy
+cockroach.port=26257
+```
+
+#### CockroachDB
+
+You can configure `--cache` and `--max-sql-memory` cockroachdb flags via
+following envvars: `CACHE` and `MAX_SQL_MEMORY`.
+
+### Client
+
+- The base provides a client deployment that bootstraps the Cockroach sql command.
+- The client deployment is useful for debugging issues and communicating with Cockroach.
+- An example command for starting a sql shell is `kubectl exec -it deployment/cockroachdb-client -c cockroachdb-client -- cockroach sql`
+
+### Admin UI
+
+In order to access admin UI, Port forward port 8080 on one of the cockroachdb- pods,
+then navigate to https://localhost:8080/
+
+### DB Console
+
+CockroachDB has a DB console [user interface](https://www.cockroachlabs.com/docs/stable/ui-overview.html).
+To log into the DB console you will require a database user.
+This can be achieved by:
+- Start a SQL shell using the client `kubectl exec -it deployment/cockroachdb-client -c cockroachdb-client -- cockroach sql`
+  - You may need to change the replica count of the client (see above)
+- Create a user using SQL `CREATE USER foo WITH PASSWORD 'changeme';`
+- Assign admin role to the user with the SQL command `GRANT admin TO foo;`
+  - This allows full access within the UI.
+- Port forward any node `kubectl port-forward cockroachdb-0 8080`
+- Use a browser to navigate to https://localhost:8080.
+- It will warn you that the certificate is not trusted, this is expected.
+
+### Architecture
+We recommend creating one instance of CockroachDB cluster per namespace instead of creating new cluster instance
+for each of applications.
+Data can be separated by creating different databases, and having one, bigger cluster instead of multiple smaller ones
+reduces infrastructure costs and maintenance overhead.

--- a/cockroachdb/examples/cfssl/certificate-authority.yaml
+++ b/cockroachdb/examples/cfssl/certificate-authority.yaml
@@ -1,0 +1,99 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "false"
+    uw.health.aggregator.enable: "false"
+  name: certificate-authority
+  labels:
+    app: certificate-authority
+spec:
+  selector:
+    app: certificate-authority
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: certificate-authority
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: certificate-authority
+  template:
+    metadata:
+      name: certificate-authority
+      labels:
+        app: certificate-authority
+    spec:
+      initContainers:
+        - name: init-config
+          image: busybox:1.29.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - "sh"
+            - "/scripts/make-config.sh"
+          env:
+            - name: AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ca.auth
+                  key: key
+            - name: EXPIRY_CLIENT_HOURS
+              valueFrom:
+                configMapKeyRef:
+                  name: ca.config
+                  key: ca.clientCert.expiryHours
+            - name: EXPIRY_SERVER_HOURS
+              valueFrom:
+                configMapKeyRef:
+                  name: ca.config
+                  key: ca.serverCert.expiryHours
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: scripts
+              mountPath: /scripts
+
+      containers:
+        - name: certificate-authority
+          image: cfssl/cfssl:latest
+          imagePullPolicy: Always
+          command:
+            - "cfssl"
+            - "serve"
+            - "-address=0.0.0.0"
+            - "-port=8080"
+            - "-config=/config/config.json"
+            - "-ca=/certs/ca.pem"
+            - "-ca-key=/certs/ca-key.pem"
+            - "-loglevel=2"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: certs
+              mountPath: /certs
+          ports:
+            - containerPort: 8080
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /api/v1/cfssl/health
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /api/v1/cfssl/health
+              port: 8080
+      volumes:
+        - name: config
+          emptyDir: {}
+        - name: scripts
+          configMap:
+            name: certificate-authority-config
+        - name: certs
+          secret:
+            secretName: ca-certs

--- a/cockroachdb/examples/cfssl/cockroach.yaml
+++ b/cockroachdb/examples/cfssl/cockroach.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cockroachdb
+spec:
+  template:
+    metadata:
+      annotations:
+        uw.systems/kyverno-inject-sidecar-request: vault-sidecar-aws
+    spec:
+      containers:
+        - name: cockroachdb
+          resources:
+            requests:
+              cpu: 0
+              memory: "1Gi"
+            limits:
+              cpu: 4
+              memory: "2Gi"
+          env:
+            - name: CACHE
+              values: 256MB
+            - name: MAX_SQL_MEMORY
+              values: 256MB
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 50Gi

--- a/cockroachdb/examples/cfssl/config/backup-config
+++ b/cockroachdb/examples/cfssl/config/backup-config
@@ -1,0 +1,2 @@
+schedule=0 0,12 * * *
+destination.url=<your s3 bucket url here>

--- a/cockroachdb/examples/cfssl/config/ca-config
+++ b/cockroachdb/examples/cfssl/config/ca-config
@@ -1,0 +1,5 @@
+ca.node.profile=client-server
+ca.client.profile=client
+ca.endpoint=certificate-authority:8080
+ca.serverCert.expiryHours=24
+ca.clientCert.expiryHours=24

--- a/cockroachdb/examples/cfssl/config/certificate-authority-config-config-template.json
+++ b/cockroachdb/examples/cfssl/config/certificate-authority-config-config-template.json
@@ -1,0 +1,43 @@
+{
+  "signing": {
+    "default": {
+      "auth_key": "unused",
+      "expiry": "1h"
+    },
+    "profiles": {
+      "client": {
+        "expiry": "%%%EXPIRY_CLIENT_HOURS%%%h",
+        "usages": [
+          "critical",
+          "digital signature",
+          "key encipherment",
+          "client auth",
+          "signing"
+        ],
+        "auth_key": "client"
+      },
+      "client-server": {
+        "expiry": "%%%EXPIRY_SERVER_HOURS%%%h",
+        "usages": [
+          "critical",
+          "digital signature",
+          "key encipherment",
+          "server auth",
+          "client auth",
+          "signing"
+        ],
+        "auth_key": "client"
+      }
+    }
+  },
+  "auth_keys": {
+    "client": {
+      "type": "standard",
+      "key": "%%%AUTH_KEY%%%"
+    },
+    "unused": {
+      "type": "standard",
+      "key": "%%%RANDOM_KEY%%%"
+    }
+  }
+}

--- a/cockroachdb/examples/cfssl/config/certificate-authority-config-make-config.sh
+++ b/cockroachdb/examples/cfssl/config/certificate-authority-config-make-config.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+RANDOM_KEY=$(hexdump -n 16 -e "4/4 \"%08X\" 1 \"\n\"" /dev/random);
+
+# This assumes that this config map is mounted in /scripts folder.
+cat /scripts/config-template.json |
+sed "s/%%%AUTH_KEY%%%/${AUTH_KEY}/g" |
+sed "s/%%%RANDOM_KEY%%%/${RANDOM_KEY}/g" |
+sed "s/%%%EXPIRY_CLIENT_HOURS%%%/${EXPIRY_CLIENT_HOURS}/g" |
+sed "s/%%%EXPIRY_SERVER_HOURS%%%/${EXPIRY_SERVER_HOURS}/g" > /config/config.json;

--- a/cockroachdb/examples/cfssl/config/cockroach
+++ b/cockroachdb/examples/cfssl/config/cockroach
@@ -1,0 +1,2 @@
+cockroach.host=cockroachdb-proxy
+cockroach.port=26257

--- a/cockroachdb/examples/cfssl/kustomization.yaml
+++ b/cockroachdb/examples/cfssl/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+secretGenerator:
+  - name: ca.auth
+    envs:
+      - secrets/ca-auth-key
+  - name: ca-certs
+    files:
+      - ca-key.pem=secrets/ca-certs-ca-key.pem
+      - ca.pem=secrets/ca-certs-ca.pem
+configMapGenerator:
+  - name: ca.config
+    envs:
+      - config/ca-config
+  - name: cockroach
+    envs:
+      - config/cockroach
+  - name: cockroach.backup.config
+    envs:
+      - config/backup-config
+  - name: certificate-authority-config
+    files:
+      - make-config.sh=config/certificate-authority-config-make-config.sh
+      - config-template.json=config/certificate-authority-config-config-template.json
+resources:
+  - certificate-authority.yaml
+  - sa.yaml
+  - github.com/utilitywarehouse/cockroachdb-manifests//base?ref=v23.2.2-1
+
+patchesStrategicMerge:
+  - cockroach.yaml

--- a/cockroachdb/examples/cfssl/sa.yaml
+++ b/cockroachdb/examples/cfssl/sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cockroachdb
+  namespace: <your namespace here>
+  annotations:
+    vault.uw.systems/aws-role: <your aws role here>

--- a/cockroachdb/examples/cfssl/secrets/ca-auth-key
+++ b/cockroachdb/examples/cfssl/secrets/ca-auth-key
@@ -1,0 +1,1 @@
+key=<your hex encoded key here>

--- a/cockroachdb/examples/cfssl/secrets/ca-certs-ca-key.pem
+++ b/cockroachdb/examples/cfssl/secrets/ca-certs-ca-key.pem
@@ -1,0 +1,3 @@
+-----BEGIN EC PRIVATE KEY-----
+<your generated private key here>
+-----END EC PRIVATE KEY-----

--- a/cockroachdb/examples/cfssl/secrets/ca-certs-ca.pem
+++ b/cockroachdb/examples/cfssl/secrets/ca-certs-ca.pem
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+<your generated certificate here>
+-----END CERTIFICATE-----

--- a/cockroachdb/kustomization.yaml
+++ b/cockroachdb/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: partner-platform
+
+secretGenerator:
+  - name: ca.auth
+    env: example-ca-auth-key
+
+configMapGenerator:
+  - name: ca.config
+    env: example-ca-config
+  - name: cockroach.backup.config
+    env: example-backup-config
+
+bases:
+  - base


### PR DESCRIPTION
For sake of standarization and discovery. 

[Slack discussion](https://utilitywarehouse.slack.com/archives/C37EHB3R6/p1718626219404169)

Content of directory `cockroachdb` created by this PR should be identical to [original repository](https://github.com/utilitywarehouse/cockroachdb-manifests). Any changes I should do (like removing CODEOWNERS file, since we have one in root of this repository), I will do in a separate PR. 