### PR TITLE
Fix `kustomize build` not running during PRs

### DIFF
--- a/.github/workflows/manifest-checks.yaml
+++ b/.github/workflows/manifest-checks.yaml
@@ -33,11 +33,12 @@ jobs:
           curl --silent --location https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.2.1/kustomize_v5.2.1_linux_amd64.tar.gz |
           tar zx -C /usr/local/bin
       - name: Run `kustomize build` across changed directories
-        run: >-
+        run: |
           set -o pipefail
-          git ls-files -- '*/kustomization.yaml'
-          | xargs kustomize-build-dirs --out-dir built-manifests/ --truncate-secrets 2>&1
-          | tee build-output
+
+          git ls-files -- '*/kustomization.yaml' \
+            | xargs kustomize-build-dirs --out-dir built-manifests/ --truncate-secrets 2>&1 \
+            | tee build-output
       - name: Check for build errors
         id: check-errors
         run: |


### PR DESCRIPTION
Were were folding the `set -o pipefail` line into the other lines in one of the steps, causing us to run:

    set -o pipefail git ls-files -- '*/kustomization.yaml' | xargs kustomize-build-dirs --out-dir built-manifests/ --truncate-secrets 2>&1 | tee build-output

This will:

* set the `pipefail` option
* set positional arguments for the current shell to `git ls-files -- '*/kustomization.yaml'` (see docs[1])
* print nothing to stdout, so pass nothing down the pipe to `kustomize-build-dirs` which will then build nothing

[1] https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#The-Set-Builtin