### PR TITLE
Fix `kustomize build` failure on cockroachdb examples

### DIFF
--- a/cockroachdb/example/cert-manager/kustomization.yaml
+++ b/cockroachdb/example/cert-manager/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
   - sa.yaml
-  - github.com/utilitywarehouse/shared-kustomize-bases/cockroachdb//manifests-cert-manager?ref=cockroachdb-1.0.0
+  - github.com/utilitywarehouse/shared-kustomize-bases/cockroachdb/manifests-cert-manager
 
 patches:
   - path: certificates-patch.yaml

--- a/cockroachdb/example/cfssl/kustomization.yaml
+++ b/cockroachdb/example/cfssl/kustomization.yaml
@@ -25,7 +25,7 @@ configMapGenerator:
 resources:
   - certificate-authority.yaml
   - sa.yaml
-  - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests?ref=1.0.0
+  - github.com/utilitywarehouse/shared-kustomize-bases/cockroachdb/manifests
 
 patchesStrategicMerge:
   - cockroach.yaml


### PR DESCRIPTION
The failure:

     stderr: Error: accumulating resources: accumulation err='accumulating resources from 'github.com/utilitywarehouse/shared-kustomize-bases/cockroachdb//manifests-cert-manager?ref=cockroachdb-1.0.0': evalsymlink failure on '/home/runner/work/shared-kustomize-bases/shared-kustomize-bases/cockroachdb/example/cert-manager/github.com/utilitywarehouse/shared-kustomize-bases/cockroachdb/manifests-cert-manager?ref=cockroachdb-1.0.0' : lstat /home/runner/work/shared-kustomize-bases/shared-kustomize-bases/cockroachdb/example/cert-manager/github.com: no such file or directory': failed to run '/usr/bin/git fetch --depth=1 https://github.com/utilitywarehouse/shared-kustomize-bases/cockroachdb cockroachdb-1.0.0': remote: Not Found

Was due to using some invalid references. Since we're in the process of moving to `release-please` and a consistent reference structure just fix this for now by dropping the references. We can come back and update them there's a versioned release.