### PR TITLE
chore: use correct tag after release

### DIFF
--- a/cockroachdb/docs/pvc-resize.md
+++ b/cockroachdb/docs/pvc-resize.md
@@ -85,7 +85,7 @@ In the `kustomize.yaml` that imports this base, apply the following type of chan
 @@ -200,3 +200,6 @@ resources:
    - 01-auth.yaml
    - 02-network-policies.yaml
-   - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.0.2-alpha
+   - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.1.0
 +
 +patchesStrategicMerge:
 +  - cockroachdb.yaml

--- a/cockroachdb/docs/scaling.md
+++ b/cockroachdb/docs/scaling.md
@@ -155,7 +155,7 @@ set the replicas count to the target value via the kustomize
 @@ -201,5 +201,9 @@ resources:
    - 01-auth.yaml
    - 02-network-policies.yaml
-   - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.0.2-alpha
+   - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.1.0
  
 +replicas:
 +  - name: cockroachdb
@@ -318,7 +318,7 @@ set the replicas count to the target value via the kustomize
 @@ -201,5 +201,9 @@ resources:
    - 01-auth.yaml
    - 02-network-policies.yaml
-   - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.0.2-alpha
+   - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.1.0
  
 replicas:
   - name: cockroachdb
@@ -381,7 +381,7 @@ ranges. To re-add nodes in such circumstances, simply increase the replica count
 @@ -201,5 +201,9 @@ resources:
    - 01-auth.yaml
    - 02-network-policies.yaml
-   - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.0.2-alpha
+   - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.1.0
  
 replicas:
   - name: cockroachdb

--- a/cockroachdb/docs/upgrade.md
+++ b/cockroachdb/docs/upgrade.md
@@ -217,8 +217,8 @@ Adjust the kustomize base ref to match the new target version. For example:
    - 00-namespace.yaml
    - 01-auth.yaml
    - 02-network-policies.yaml
--  - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.0.2-alpha
-+  - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.0.2-alpha
+-  - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.1.0
++  - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.1.0
  
  patchesStrategicMerge:
    - cockroach.yaml
@@ -294,8 +294,8 @@ above the previous (excluding the patch element).
    - 00-namespace.yaml
    - 01-auth.yaml
    - 02-network-policies.yaml
--  - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.0.2-alpha
-+  - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.0.2-alpha
+-  - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.1.0
++  - github.com/utilitywarehouse/shared-kustomize-bases//cockroachdb/manifests-cfssl?ref=cockroachdb/v1.1.0
  
  patchesStrategicMerge:
    - cockroach.yaml

--- a/cockroachdb/example/cfssl/kustomization.yaml
+++ b/cockroachdb/example/cfssl/kustomization.yaml
@@ -25,7 +25,7 @@ configMapGenerator:
 resources:
   - certificate-authority.yaml
   - sa.yaml
-  - github.com/utilitywarehouse/shared-kustomize-bases/cockroachdb/manifests-cfssl?ref=cockroachdb/v1.0.2-alpha
+  - github.com/utilitywarehouse/shared-kustomize-bases/cockroachdb/manifests-cfssl
 
 patches:
   - path: cockroach.yaml


### PR DESCRIPTION
Previous tag was just a temporary tag used for sake of pipeline passing