### PR TITLE
Increase duration of CA certificate

### DIFF
--- a/cockroachdb/manifests-cert-manager/certificates.yaml
+++ b/cockroachdb/manifests-cert-manager/certificates.yaml
@@ -20,6 +20,8 @@ spec:
     name: cockroachdb-selfsigned-issuer
     kind: Issuer
     group: cert-manager.io
+  duration: 4320h # 6 months
+  renewBefore: 2160h # 3 months
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer


### PR DESCRIPTION
This is a long shot, but perhaps it helps resolving the issue of the
secret not being updated when cert-manager renews a certificate. The
idea is taken from:
https://github.com/cert-manager/cert-manager/issues/5851#issuecomment-2413359368
